### PR TITLE
Fix bulk delete: reset UI after deletion

### DIFF
--- a/tracker.html
+++ b/tracker.html
@@ -1327,6 +1327,8 @@ function deselectAll() {
   selectedIds.clear();
   renderTable();
   updateBulkBar();
+  const selectAllCb = document.querySelector('#thead-row input[type="checkbox"]');
+  if (selectAllCb) selectAllCb.checked = false;
 }
 
 function updateBulkBar() {
@@ -1361,7 +1363,7 @@ async function bulkDelete() {
   allMetrics = allMetrics.filter(m => !selectedIds.has(m.id));
   selectedIds.clear();
   expandedId = null;
-  applyFilters();
+  renderApp();
 }
 
 // --- New Metric Wizard ---


### PR DESCRIPTION
## Summary

- Bulk bar now hides and stats update after deleting metrics
- Deselect All explicitly unchecks the header checkbox
- Root cause: was calling `applyFilters()` (only re-renders table) instead of `renderApp()` (rebuilds entire UI including stats and bulk bar)

## Test plan

- [ ] Select 5+ metrics → Delete Selected → bar disappears, counts update
- [ ] Deselect All → everything clears, header checkbox unchecks
- [ ] Individual uncheck → header checkbox syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)