### PR TITLE
feat: Call Prep — consultant book + precall snapshot pages

### DIFF
--- a/builder/src/App.jsx
+++ b/builder/src/App.jsx
@@ -14,6 +14,7 @@ import Scorecard from './pages/Scorecard';
 import McpToken from './pages/McpToken';
 import SaasDataExport from './pages/SaasDataExport';
 import CallPrep from './pages/CallPrep';
+import CallPrepBook from './pages/CallPrepBook';
 import { UserProvider } from './contexts/UserContext';
 import { useMetrics } from './hooks/useMetrics';
 import { useBqAuth } from './hooks/useBqAuth';
@@ -112,6 +113,7 @@ export default function App() {
               <Scorecard metrics={metrics} bqConnected={connected} onConnect={connect} />
             } />
             <Route path="/call-prep" element={<CallPrep />} />
+            <Route path="/call-prep/:consultant" element={<CallPrepBook />} />
             <Route path="/mcp-token" element={<McpToken userEmail={userEmail} bqConnected={connected} onConnect={connect} />} />
             <Route path="/admin/registry" element={<Registry />} />
             <Route path="/admin/dimensions" element={<Dimensions />} />

--- a/builder/src/App.jsx
+++ b/builder/src/App.jsx
@@ -14,6 +14,7 @@ import Scorecard from './pages/Scorecard';
 import McpToken from './pages/McpToken';
 import SaasDataExport from './pages/SaasDataExport';
 import CallPrep from './pages/CallPrep';
+import CallPrepAccount from './pages/CallPrepAccount';
 import CallPrepBook from './pages/CallPrepBook';
 import { UserProvider } from './contexts/UserContext';
 import { useMetrics } from './hooks/useMetrics';
@@ -113,6 +114,7 @@ export default function App() {
               <Scorecard metrics={metrics} bqConnected={connected} onConnect={connect} />
             } />
             <Route path="/call-prep" element={<CallPrep />} />
+            <Route path="/call-prep/account/:recordId" element={<CallPrepAccount />} />
             <Route path="/call-prep/:consultant" element={<CallPrepBook />} />
             <Route path="/mcp-token" element={<McpToken userEmail={userEmail} bqConnected={connected} onConnect={connect} />} />
             <Route path="/admin/registry" element={<Registry />} />

--- a/builder/src/App.jsx
+++ b/builder/src/App.jsx
@@ -13,6 +13,7 @@ import AdminInsights from './pages/AdminInsights';
 import Scorecard from './pages/Scorecard';
 import McpToken from './pages/McpToken';
 import SaasDataExport from './pages/SaasDataExport';
+import CallPrep from './pages/CallPrep';
 import { UserProvider } from './contexts/UserContext';
 import { useMetrics } from './hooks/useMetrics';
 import { useBqAuth } from './hooks/useBqAuth';
@@ -110,6 +111,7 @@ export default function App() {
               metricsLoading ? <Loading /> :
               <Scorecard metrics={metrics} bqConnected={connected} onConnect={connect} />
             } />
+            <Route path="/call-prep" element={<CallPrep />} />
             <Route path="/mcp-token" element={<McpToken userEmail={userEmail} bqConnected={connected} onConnect={connect} />} />
             <Route path="/admin/registry" element={<Registry />} />
             <Route path="/admin/dimensions" element={<Dimensions />} />

--- a/builder/src/components/TopBar.jsx
+++ b/builder/src/components/TopBar.jsx
@@ -32,6 +32,7 @@ export default function TopBar({ connected, userEmail, onConnect }) {
         <a href="/method-metrics/index.html" style={{ ...styles.logo, textDecoration: 'none' }}>Method</a>
         <NavLink to="/chat" style={routerNavStyle}>Chat</NavLink>
         <NavLink to="/dashboards" style={routerNavStyle}>Dashboards</NavLink>
+        <NavLink to="/call-prep" style={routerNavStyle}>Call Prep</NavLink>
         <a href="../tracker.html" style={styles.navLink}>Metrics</a>
       </div>
       <div style={styles.right}>

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -47,3 +47,58 @@ export function buildAccountSnapshotsSql(recordId) {
     WHERE account_record_id = ${id}
     ORDER BY snapshot_date DESC`;
 }
+
+const toInt = (v, fallback = null) => (v == null || v === '' ? fallback : parseInt(v, 10));
+const toFloat = (v) => (v == null || v === '' ? null : parseFloat(v));
+const toBool = (v) => v === true || v === 'true';
+const toStr = (v) => (v == null || v === '' ? null : String(v));
+
+/** Convert a raw BQ REST row (all strings, [{v}] arrays) into typed camelCase. */
+export function normalizeSnapshotRow(row) {
+  return {
+    accountRecordId: toInt(row.account_record_id),
+    accountName: toStr(row.account_name),
+    snapshotDate: toStr(row.snapshot_date),
+    callType: toStr(row.call_type),
+    consultant: toStr(row.consultant),
+    accountAgeMonths: toFloat(row.account_age_months),
+    signupDate: toStr(row.signup_date),
+    depEnrolled: toBool(row.dep_enrolled),
+    multiEntityParentName: toStr(row.multi_entity_parent_name),
+    syncFailCount: toInt(row.sync_fail_count, 0),
+    syncStatus: toStr(row.sync_status)?.toLowerCase() ?? null,
+    ttTotalHours: toFloat(row.tt_total_hours),
+    ttSessionCount: toInt(row.tt_session_count),
+    ttLastSessionDate: toStr(row.tt_last_session_date),
+    casesOpenCount: toInt(row.cases_open_count, 0),
+    casesClosed90dCount: toInt(row.cases_closed_90d_count, 0),
+    depSignals: (row.dep_signals || []).map((x) => x?.v).filter(Boolean),
+    industryL1: toStr(row.industry_l1),
+    industryL2: toStr(row.industry_l2),
+    industryL3: toStr(row.industry_l3),
+    operatingModel: toStr(row.operating_model),
+    bqConfidence: toFloat(row.bq_confidence),
+    docLink: toStr(row.doc_link),
+    createdAt: toStr(row.created_at),
+  };
+}
+
+const STALE_SESSION_DAYS = 30;
+const MS_PER_DAY = 86400000;
+
+/**
+ * v1 attention rules — deliberately dumb (see spec). Returns UI-ready labels.
+ * `snapshot` is a normalized Snapshot or null (account with no snapshot yet).
+ */
+export function computeFlags(snapshot, todayIso) {
+  if (!snapshot) return ['no snapshot'];
+  const flags = [];
+  if (snapshot.syncFailCount > 0) flags.push('sync failing');
+  if (snapshot.casesOpenCount > 0) flags.push('open cases');
+  const last = snapshot.ttLastSessionDate;
+  const staleDays = last
+    ? Math.floor((Date.parse(todayIso) - Date.parse(last)) / MS_PER_DAY)
+    : Infinity;
+  if (staleDays >= STALE_SESSION_DAYS) flags.push('no recent sessions');
+  return flags;
+}

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -6,6 +6,7 @@
 // consultant's book" = distinct accounts they have snapshots for.
 
 import { validateInt } from './sanitize.js';
+import { queryBqWithRetry } from './bigquery.js';
 
 export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
 
@@ -101,4 +102,23 @@ export function computeFlags(snapshot, todayIso) {
     : Infinity;
   if (staleDays >= STALE_SESSION_DAYS) flags.push('no recent sessions');
   return flags;
+}
+
+export async function fetchConsultants({ query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildConsultantsSql());
+  return rows.map((r) => ({
+    consultant: toStr(r.consultant),
+    accountCount: toInt(r.account_count, 0),
+    lastSnapshotDate: toStr(r.last_snapshot_date),
+  }));
+}
+
+export async function fetchBook(consultant, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildBookSql(consultant));
+  return rows.map(normalizeSnapshotRow);
+}
+
+export async function fetchAccountSnapshots(recordId, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildAccountSnapshotsSql(recordId));
+  return rows.map(normalizeSnapshotRow);
 }

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -1,0 +1,49 @@
+// Call Prep data layer. Reads b.saltzman's precall snapshot table directly
+// from the browser via the shared BQ OAuth layer (see bigquery.js).
+//
+// Table contract: docs/superpowers/specs/2026-07-13-call-prep-design.md.
+// Book fallback: until call_prep.consultant_book exists upstream, "a
+// consultant's book" = distinct accounts they have snapshots for.
+
+import { validateInt } from './sanitize.js';
+
+export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
+
+export function buildConsultantsSql() {
+  return `
+    SELECT
+      consultant,
+      COUNT(DISTINCT account_record_id) AS account_count,
+      MAX(snapshot_date) AS last_snapshot_date
+    FROM ${CALL_PREP_TABLE}
+    WHERE consultant IS NOT NULL
+    GROUP BY consultant
+    ORDER BY consultant`;
+}
+
+// BigQuery single-quoted string literals escape via backslash (\'), not the
+// doubled-quote ('') convention used elsewhere in this repo. sanitize.js's
+// escapeBqString implements doubling, which does not neutralize a quote in
+// a BQ literal, so it is not used here — this builds the literal directly.
+function escapeSqlLiteral(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+export function buildBookSql(consultant) {
+  const name = escapeSqlLiteral(consultant);
+  return `
+    SELECT *
+    FROM ${CALL_PREP_TABLE}
+    WHERE consultant = '${name}'
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY account_record_id ORDER BY snapshot_date DESC) = 1
+    ORDER BY snapshot_date DESC`;
+}
+
+export function buildAccountSnapshotsSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT *
+    FROM ${CALL_PREP_TABLE}
+    WHERE account_record_id = ${id}
+    ORDER BY snapshot_date DESC`;
+}

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -53,6 +53,12 @@ const toInt = (v, fallback = null) => (v == null || v === '' ? fallback : parseI
 const toFloat = (v) => (v == null || v === '' ? null : parseFloat(v));
 const toBool = (v) => v === true || v === 'true';
 const toStr = (v) => (v == null || v === '' ? null : String(v));
+// Only allow http(s) URLs through — BQ-sourced doc_link values render in an
+// <a href>, and React does not block javascript:/data: URLs there.
+const toHttpUrl = (v) => {
+  const s = toStr(v);
+  return s && /^https?:\/\//i.test(s) ? s : null;
+};
 
 /** Convert a raw BQ REST row (all strings, [{v}] arrays) into typed camelCase. */
 export function normalizeSnapshotRow(row) {
@@ -79,7 +85,7 @@ export function normalizeSnapshotRow(row) {
     industryL3: toStr(row.industry_l3),
     operatingModel: toStr(row.operating_model),
     bqConfidence: toFloat(row.bq_confidence),
-    docLink: toStr(row.doc_link),
+    docLink: toHttpUrl(row.doc_link),
     createdAt: toStr(row.created_at),
   };
 }

--- a/builder/src/pages/CallPrep.jsx
+++ b/builder/src/pages/CallPrep.jsx
@@ -1,0 +1,77 @@
+// Call Prep — consultant picker. Route: #/call-prep
+// Lists consultants found in call_prep.snapshots; remembers the last
+// selection so returning users land one click from their book.
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchConsultants } from '../lib/callPrep';
+
+const CONSULTANT_KEY = 'method_callprep_consultant';
+
+const s = {
+  wrap: { maxWidth: 720, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
+  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a', marginBottom: 4 },
+  sub: { fontSize: 14, color: '#6b7280', marginBottom: 28 },
+  row: {
+    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+    padding: '14px 16px', border: '1px solid #e2e5e9', borderRadius: 8,
+    marginBottom: 8, cursor: 'pointer', background: '#fff',
+  },
+  rowName: { fontSize: 15, fontWeight: 600, color: '#1a1a1a' },
+  rowMeta: { fontSize: 12, color: '#8a9099', fontFamily: "'JetBrains Mono', monospace" },
+  note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
+  error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+};
+
+export default function CallPrep() {
+  const navigate = useNavigate();
+  const [consultants, setConsultants] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    // Returning user: skip the picker.
+    const remembered = localStorage.getItem(CONSULTANT_KEY);
+    if (remembered) {
+      navigate(`/call-prep/${encodeURIComponent(remembered)}`, { replace: true });
+      return;
+    }
+    fetchConsultants()
+      .then(setConsultants)
+      .catch((e) => setError(e?.message || String(e)));
+  }, [navigate]);
+
+  const pick = (name) => {
+    localStorage.setItem(CONSULTANT_KEY, name);
+    navigate(`/call-prep/${encodeURIComponent(name)}`);
+  };
+
+  if (error) {
+    return (
+      <div style={s.wrap}>
+        <div style={s.error}>
+          {/BQ 403/.test(error)
+            ? 'You don’t have access to the call_prep dataset yet. Ask Nic for the BigQuery grant.'
+            : `Couldn’t load consultants: ${error}`}
+        </div>
+      </div>
+    );
+  }
+  if (!consultants) return <div style={s.wrap}><div style={s.note}>Loading consultants…</div></div>;
+  if (!consultants.length) {
+    return <div style={s.wrap}><div style={s.note}>No snapshots in call_prep yet.</div></div>;
+  }
+
+  return (
+    <div style={s.wrap}>
+      <h1 style={s.title}>Call Prep</h1>
+      <p style={s.sub}>Pick your name to see your accounts. We’ll remember it next time.</p>
+      {consultants.map((c) => (
+        <div key={c.consultant} style={s.row} onClick={() => pick(c.consultant)}>
+          <span style={s.rowName}>{c.consultant}</span>
+          <span style={s.rowMeta}>
+            {c.accountCount} account{c.accountCount === 1 ? '' : 's'} · last snapshot {c.lastSnapshotDate}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -1,0 +1,162 @@
+// Call Prep — account snapshot. Route: #/call-prep/account/:recordId
+// The page Slack deep-links to. Renders the latest snapshot natively;
+// a date selector exposes history. Narrative lives only in the Google
+// Doc until upstream lands it in BQ — we link out via doc_link.
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { fetchAccountSnapshots } from '../lib/callPrep';
+
+const s = {
+  wrap: { maxWidth: 760, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
+  crumb: { fontSize: 13, color: '#059669', cursor: 'pointer', marginBottom: 16, display: 'inline-block' },
+  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 },
+  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a' },
+  sub: { fontSize: 13, color: '#6b7280', marginBottom: 24 },
+  select: { fontSize: 13, padding: '4px 8px', borderRadius: 6, border: '1px solid #e2e5e9' },
+  section: { marginBottom: 24 },
+  sectionTitle: {
+    fontSize: 10, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase',
+    color: '#8a9099', fontFamily: "'JetBrains Mono', monospace", marginBottom: 10,
+  },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 },
+  cell: { background: '#fff', border: '1px solid #e2e5e9', borderRadius: 8, padding: '10px 14px' },
+  cellLabel: { fontSize: 11, color: '#8a9099', marginBottom: 2 },
+  cellValue: { fontSize: 15, fontWeight: 600, color: '#1a1a1a' },
+  signal: {
+    display: 'inline-block', fontSize: 12, color: '#1d4ed8', background: '#eff6ff',
+    border: '1px solid #bfdbfe', borderRadius: 4, padding: '3px 10px', margin: '0 6px 6px 0',
+  },
+  docBtn: {
+    display: 'inline-block', padding: '8px 18px', background: '#059669', color: '#fff',
+    borderRadius: 6, fontSize: 13, fontWeight: 600, textDecoration: 'none',
+  },
+  note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
+  error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+};
+
+const Cell = ({ label, value }) => (
+  <div style={s.cell}>
+    <div style={s.cellLabel}>{label}</div>
+    <div style={s.cellValue}>{value ?? '—'}</div>
+  </div>
+);
+
+export default function CallPrepAccount() {
+  const { recordId } = useParams();
+  const navigate = useNavigate();
+  const [history, setHistory] = useState(null);
+  const [error, setError] = useState('');
+  const [selectedDate, setSelectedDate] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHistory(null);
+    setSelectedDate(null);
+    setError('');
+    fetchAccountSnapshots(recordId)
+      .then((h) => { if (!cancelled) setHistory(h); })
+      .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
+    return () => { cancelled = true; };
+  }, [recordId]);
+
+  const snap = useMemo(() => {
+    if (!history?.length) return null;
+    return history.find((h) => h.snapshotDate === selectedDate) || history[0];
+  }, [history, selectedDate]);
+
+  if (error) return <div style={s.wrap}><div style={s.error}>Couldn’t load snapshot: {error}</div></div>;
+  if (!history) return <div style={s.wrap}><div style={s.note}>Loading snapshot…</div></div>;
+  if (!history.length) {
+    return (
+      <div style={s.wrap}>
+        <span style={s.crumb} onClick={() => navigate('/call-prep')}>← Call Prep</span>
+        <div style={s.note}>No snapshots exist for account {recordId} yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={s.wrap}>
+      <span style={s.crumb} onClick={() => navigate(`/call-prep/${encodeURIComponent(snap.consultant || '')}`)}>
+        ← {snap.consultant}’s book
+      </span>
+      <div style={s.head}>
+        <h1 style={s.title}>{snap.accountName ?? '—'}</h1>
+        {history.length > 1 ? (
+          <select
+            style={s.select}
+            value={snap.snapshotDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
+          >
+            {history.map((h) => (
+              <option key={h.snapshotDate} value={h.snapshotDate}>{h.snapshotDate}</option>
+            ))}
+          </select>
+        ) : (
+          <span style={{ fontSize: 13, color: '#6b7280' }}>{snap.snapshotDate}</span>
+        )}
+      </div>
+      <p style={s.sub}>
+        {snap.callType} · {snap.consultant} · account #{snap.accountRecordId}
+      </p>
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Account</div>
+        <div style={s.grid}>
+          <Cell label="Signup date" value={snap.signupDate} />
+          <Cell label="Age (months)" value={snap.accountAgeMonths != null ? snap.accountAgeMonths.toFixed(1) : null} />
+          <Cell label="DEP enrolled" value={snap.depEnrolled ? 'yes' : 'no'} />
+          <Cell label="Parent" value={snap.multiEntityParentName} />
+        </div>
+      </div>
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Sync</div>
+        <div style={s.grid}>
+          <Cell label="Status" value={snap.syncStatus} />
+          <Cell label="Fail count" value={snap.syncFailCount} />
+        </div>
+      </div>
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Time tracking</div>
+        <div style={s.grid}>
+          <Cell label="Total hours" value={snap.ttTotalHours} />
+          <Cell label="Sessions" value={snap.ttSessionCount} />
+          <Cell label="Last session" value={snap.ttLastSessionDate} />
+        </div>
+      </div>
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Cases</div>
+        <div style={s.grid}>
+          <Cell label="Open" value={snap.casesOpenCount} />
+          <Cell label="Closed (90d)" value={snap.casesClosed90dCount} />
+        </div>
+      </div>
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Classification</div>
+        <div style={s.grid}>
+          <Cell label="Industry" value={[snap.industryL1, snap.industryL2, snap.industryL3].filter(Boolean).join(' › ') || null} />
+          <Cell label="Operating model" value={snap.operatingModel} />
+          <Cell label="Confidence" value={snap.bqConfidence != null ? `${Math.round(snap.bqConfidence * 100)}%` : null} />
+        </div>
+      </div>
+
+      {snap.depSignals.length > 0 && (
+        <div style={s.section}>
+          <div style={s.sectionTitle}>DEP signals</div>
+          <div>{snap.depSignals.map((sig) => <span key={sig} style={s.signal}>{sig}</span>)}</div>
+        </div>
+      )}
+
+      <div style={s.section}>
+        <div style={s.sectionTitle}>Prep write-up</div>
+        {snap.docLink
+          ? <a href={snap.docLink} target="_blank" rel="noreferrer" style={s.docBtn}>Open prep doc ↗</a>
+          : <span style={{ fontSize: 13, color: '#6b7280' }}>Write-up unavailable for this snapshot.</span>}
+      </div>
+    </div>
+  );
+}

--- a/builder/src/pages/CallPrepBook.jsx
+++ b/builder/src/pages/CallPrepBook.jsx
@@ -36,10 +36,13 @@ export default function CallPrepBook() {
   const [error, setError] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
     setBook(null);
+    setError('');
     fetchBook(consultant)
-      .then(setBook)
-      .catch((e) => setError(e?.message || String(e)));
+      .then((b) => { if (!cancelled) setBook(b); })
+      .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
+    return () => { cancelled = true; };
   }, [consultant]);
 
   const todayIso = new Date().toISOString().slice(0, 10);
@@ -48,7 +51,7 @@ export default function CallPrepBook() {
     if (!book) return [];
     return book
       .map((snap) => ({ snap, flags: computeFlags(snap, todayIso) }))
-      .sort((a, b) => b.flags.length - a.flags.length || a.snap.accountName.localeCompare(b.snap.accountName));
+      .sort((a, b) => b.flags.length - a.flags.length || (a.snap.accountName ?? '').localeCompare(b.snap.accountName ?? ''));
   }, [book, todayIso]);
 
   const switchConsultant = () => {
@@ -83,7 +86,7 @@ export default function CallPrepBook() {
               <tr
                 key={snap.accountRecordId}
                 style={s.rowClickable}
-                onClick={() => navigate(`/call-prep/account/${snap.accountRecordId}`)}
+                onClick={() => navigate(`/call-prep/account/${encodeURIComponent(snap.accountRecordId)}`)}
               >
                 <td style={{ ...s.td, fontWeight: 600 }}>{snap.accountName}</td>
                 <td style={s.td}>{snap.syncStatus ?? '—'}</td>

--- a/builder/src/pages/CallPrepBook.jsx
+++ b/builder/src/pages/CallPrepBook.jsx
@@ -1,0 +1,105 @@
+// Call Prep — one consultant's book. Route: #/call-prep/:consultant
+// One row per account (latest snapshot), flagged accounts sort first.
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { fetchBook, computeFlags } from '../lib/callPrep';
+
+const CONSULTANT_KEY = 'method_callprep_consultant';
+
+const s = {
+  wrap: { maxWidth: 920, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
+  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 24 },
+  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a' },
+  switchLink: { fontSize: 13, color: '#059669', cursor: 'pointer', textDecoration: 'underline' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 14 },
+  th: {
+    textAlign: 'left', padding: '8px 12px', fontSize: 10, fontWeight: 700,
+    letterSpacing: '.12em', textTransform: 'uppercase', color: '#8a9099',
+    fontFamily: "'JetBrains Mono', monospace", borderBottom: '1px solid #e2e5e9',
+  },
+  td: { padding: '12px', borderBottom: '1px solid #f0f1f3', color: '#1a1a1a' },
+  rowClickable: { cursor: 'pointer' },
+  flag: {
+    display: 'inline-block', fontSize: 11, fontWeight: 600, color: '#b45309',
+    background: '#fffbeb', border: '1px solid #fde68a', borderRadius: 4,
+    padding: '2px 8px', marginRight: 6,
+  },
+  ok: { fontSize: 12, color: '#059669' },
+  note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
+  error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+};
+
+export default function CallPrepBook() {
+  const { consultant } = useParams();
+  const navigate = useNavigate();
+  const [book, setBook] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setBook(null);
+    fetchBook(consultant)
+      .then(setBook)
+      .catch((e) => setError(e?.message || String(e)));
+  }, [consultant]);
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+
+  const rows = useMemo(() => {
+    if (!book) return [];
+    return book
+      .map((snap) => ({ snap, flags: computeFlags(snap, todayIso) }))
+      .sort((a, b) => b.flags.length - a.flags.length || a.snap.accountName.localeCompare(b.snap.accountName));
+  }, [book, todayIso]);
+
+  const switchConsultant = () => {
+    localStorage.removeItem(CONSULTANT_KEY);
+    navigate('/call-prep');
+  };
+
+  if (error) return <div style={s.wrap}><div style={s.error}>Couldn’t load book: {error}</div></div>;
+  if (!book) return <div style={s.wrap}><div style={s.note}>Loading {consultant}’s accounts…</div></div>;
+
+  return (
+    <div style={s.wrap}>
+      <div style={s.head}>
+        <h1 style={s.title}>{consultant} — {book.length} account{book.length === 1 ? '' : 's'}</h1>
+        <span style={s.switchLink} onClick={switchConsultant}>switch consultant</span>
+      </div>
+      {!book.length && <div style={s.note}>No snapshots for {consultant} yet.</div>}
+      {book.length > 0 && (
+        <table style={s.table}>
+          <thead>
+            <tr>
+              <th style={s.th}>Account</th>
+              <th style={s.th}>Sync</th>
+              <th style={s.th}>Open cases</th>
+              <th style={s.th}>Last session</th>
+              <th style={s.th}>Last snapshot</th>
+              <th style={s.th}>Attention</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ snap, flags }) => (
+              <tr
+                key={snap.accountRecordId}
+                style={s.rowClickable}
+                onClick={() => navigate(`/call-prep/account/${snap.accountRecordId}`)}
+              >
+                <td style={{ ...s.td, fontWeight: 600 }}>{snap.accountName}</td>
+                <td style={s.td}>{snap.syncStatus ?? '—'}</td>
+                <td style={s.td}>{snap.casesOpenCount}</td>
+                <td style={s.td}>{snap.ttLastSessionDate ?? '—'}</td>
+                <td style={s.td}>{snap.snapshotDate}</td>
+                <td style={s.td}>
+                  {flags.length
+                    ? flags.map((f) => <span key={f} style={s.flag}>{f}</span>)
+                    : <span style={s.ok}>ok</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -84,6 +84,7 @@ describe('normalizeSnapshotRow', () => {
     expect(s.depSignals).toEqual(['signal-a', 'signal-b']);
     expect(s.bqConfidence).toBeCloseTo(0.85);
     expect(s.docLink).toBe('https://docs.google.com/document/d/abc');
+    expect(s.createdAt).toBe('1.78404058517258E9');
   });
 
   it('tolerates nulls and missing repeated fields', () => {

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CALL_PREP_TABLE,
+  buildConsultantsSql,
+  buildBookSql,
+  buildAccountSnapshotsSql,
+} from '../../src/lib/callPrep.js';
+
+describe('buildConsultantsSql', () => {
+  it('aggregates consultants from the snapshots table', () => {
+    const sql = buildConsultantsSql();
+    expect(sql).toContain(CALL_PREP_TABLE);
+    expect(sql).toMatch(/GROUP BY consultant/);
+    expect(sql).toMatch(/COUNT\(DISTINCT account_record_id\)/);
+  });
+});
+
+describe('buildBookSql', () => {
+  it('filters by consultant and keeps latest row per account', () => {
+    const sql = buildBookSql('Brandon Saltzman');
+    expect(sql).toContain("consultant = 'Brandon Saltzman'");
+    expect(sql).toMatch(/QUALIFY ROW_NUMBER\(\) OVER \(PARTITION BY account_record_id ORDER BY snapshot_date DESC\) = 1/);
+  });
+
+  it('escapes quotes in consultant names', () => {
+    const sql = buildBookSql("O'Brien");
+    expect(sql).toContain("O\\'Brien");
+    expect(sql).not.toContain("= 'O'Brien'");
+  });
+});
+
+describe('buildAccountSnapshotsSql', () => {
+  it('filters by record id, newest first', () => {
+    const sql = buildAccountSnapshotsSql('141376');
+    expect(sql).toContain('account_record_id = 141376');
+    expect(sql).toMatch(/ORDER BY snapshot_date DESC/);
+  });
+
+  it('rejects non-integer record ids', () => {
+    expect(() => buildAccountSnapshotsSql('141376; DROP TABLE x')).toThrow();
+    expect(() => buildAccountSnapshotsSql('abc')).toThrow();
+  });
+});

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -96,6 +96,12 @@ describe('normalizeSnapshotRow', () => {
     expect(s.syncFailCount).toBe(0);
     expect(s.casesOpenCount).toBe(0);
   });
+
+  it('nulls docLink unless it is an http(s) URL', () => {
+    expect(normalizeSnapshotRow({ ...bqRow, doc_link: 'javascript:alert(1)' }).docLink).toBe(null);
+    expect(normalizeSnapshotRow({ ...bqRow, doc_link: 'https://docs.google.com/document/d/abc' }).docLink)
+      .toBe('https://docs.google.com/document/d/abc');
+  });
 });
 
 describe('computeFlags', () => {

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -6,6 +6,7 @@ import {
   buildAccountSnapshotsSql,
 } from '../../src/lib/callPrep.js';
 import { normalizeSnapshotRow, computeFlags } from '../../src/lib/callPrep.js';
+import { fetchConsultants, fetchBook, fetchAccountSnapshots } from '../../src/lib/callPrep.js';
 
 describe('buildConsultantsSql', () => {
   it('aggregates consultants from the snapshots table', () => {
@@ -119,5 +120,31 @@ describe('computeFlags', () => {
 
   it('flags missing snapshot', () => {
     expect(computeFlags(null, today)).toEqual(['no snapshot']);
+  });
+});
+
+describe('fetch functions', () => {
+  it('fetchConsultants normalizes count fields', async () => {
+    const query = async () => ({
+      rows: [{ consultant: 'Brandon Saltzman', account_count: '2', last_snapshot_date: '2026-07-13' }],
+    });
+    const out = await fetchConsultants({ query });
+    expect(out).toEqual([
+      { consultant: 'Brandon Saltzman', accountCount: 2, lastSnapshotDate: '2026-07-13' },
+    ]);
+  });
+
+  it('fetchBook passes built SQL to query and normalizes rows', async () => {
+    const seen = [];
+    const query = async (sql) => { seen.push(sql); return { rows: [bqRow] }; };
+    const out = await fetchBook('Brandon Saltzman', { query });
+    expect(seen[0]).toContain("consultant = 'Brandon Saltzman'");
+    expect(out[0].accountRecordId).toBe(141376);
+  });
+
+  it('fetchAccountSnapshots validates id before querying', async () => {
+    const query = async () => ({ rows: [] });
+    await expect(fetchAccountSnapshots('bad-id', { query })).rejects.toThrow();
+    expect(await fetchAccountSnapshots('141376', { query })).toEqual([]);
   });
 });

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -5,6 +5,7 @@ import {
   buildBookSql,
   buildAccountSnapshotsSql,
 } from '../../src/lib/callPrep.js';
+import { normalizeSnapshotRow, computeFlags } from '../../src/lib/callPrep.js';
 
 describe('buildConsultantsSql', () => {
   it('aggregates consultants from the snapshots table', () => {
@@ -39,5 +40,83 @@ describe('buildAccountSnapshotsSql', () => {
   it('rejects non-integer record ids', () => {
     expect(() => buildAccountSnapshotsSql('141376; DROP TABLE x')).toThrow();
     expect(() => buildAccountSnapshotsSql('abc')).toThrow();
+  });
+});
+
+// BQ REST returns all scalars as strings and REPEATED fields as [{v}] arrays.
+const bqRow = {
+  account_record_id: '141376',
+  account_name: 'Montana Mixers',
+  snapshot_date: '2026-07-09',
+  call_type: 'PPU',
+  consultant: 'Brandon Saltzman',
+  account_age_months: '14.5',
+  signup_date: '2025-04-20',
+  dep_enrolled: 'true',
+  multi_entity_parent_name: null,
+  sync_fail_count: '0',
+  sync_status: 'DISCONNECTED',
+  tt_total_hours: '12.5',
+  tt_session_count: '4',
+  tt_last_session_date: '2026-06-30',
+  cases_open_count: '1',
+  cases_closed_90d_count: '2',
+  dep_signals: [{ v: 'signal-a' }, { v: 'signal-b' }],
+  industry_l1: 'Manufacturing',
+  industry_l2: null,
+  industry_l3: null,
+  operating_model: 'B2B',
+  bq_confidence: '0.85',
+  doc_link: 'https://docs.google.com/document/d/abc',
+  created_at: '1.78404058517258E9',
+};
+
+describe('normalizeSnapshotRow', () => {
+  it('casts numerics, lowercases sync_status, unwraps repeated fields', () => {
+    const s = normalizeSnapshotRow(bqRow);
+    expect(s.accountRecordId).toBe(141376);
+    expect(s.accountName).toBe('Montana Mixers');
+    expect(s.syncStatus).toBe('disconnected');
+    expect(s.syncFailCount).toBe(0);
+    expect(s.casesOpenCount).toBe(1);
+    expect(s.ttTotalHours).toBeCloseTo(12.5);
+    expect(s.depEnrolled).toBe(true);
+    expect(s.depSignals).toEqual(['signal-a', 'signal-b']);
+    expect(s.bqConfidence).toBeCloseTo(0.85);
+    expect(s.docLink).toBe('https://docs.google.com/document/d/abc');
+  });
+
+  it('tolerates nulls and missing repeated fields', () => {
+    const s = normalizeSnapshotRow({ account_record_id: '90430', account_name: 'Wave Distro' });
+    expect(s.accountRecordId).toBe(90430);
+    expect(s.depSignals).toEqual([]);
+    expect(s.syncStatus).toBe(null);
+    expect(s.syncFailCount).toBe(0);
+    expect(s.casesOpenCount).toBe(0);
+  });
+});
+
+describe('computeFlags', () => {
+  const base = normalizeSnapshotRow(bqRow);
+  const today = '2026-07-14';
+
+  it('flags sync failures', () => {
+    expect(computeFlags({ ...base, syncFailCount: 3 }, today)).toContain('sync failing');
+    expect(computeFlags(base, today)).not.toContain('sync failing');
+  });
+
+  it('flags open cases', () => {
+    expect(computeFlags(base, today)).toContain('open cases'); // casesOpenCount: 1
+    expect(computeFlags({ ...base, casesOpenCount: 0 }, today)).not.toContain('open cases');
+  });
+
+  it('flags stale time tracking at 30+ days, not before', () => {
+    expect(computeFlags({ ...base, ttLastSessionDate: '2026-06-14' }, today)).toContain('no recent sessions'); // exactly 30d
+    expect(computeFlags({ ...base, ttLastSessionDate: '2026-06-15' }, today)).not.toContain('no recent sessions'); // 29d
+    expect(computeFlags({ ...base, ttLastSessionDate: null }, today)).toContain('no recent sessions');
+  });
+
+  it('flags missing snapshot', () => {
+    expect(computeFlags(null, today)).toEqual(['no snapshot']);
   });
 });


### PR DESCRIPTION
Call Prep section for the builder app, reading `project-for-method-dw.call_prep.snapshots` directly via the existing browser BQ OAuth layer.

- `#/call-prep` — consultant picker (remembers selection)
- `#/call-prep/:consultant` — book of accounts with attention flags (sync failing / open cases / no recent sessions), flagged-first sort
- `#/call-prep/account/:recordId` — account snapshot page (Slack deep-link target) with history selector + prep-doc link
- New data layer `builder/src/lib/callPrep.js` — injection-safe SQL builders, BQ-REST row normalization (string scalars, [{v}] repeated fields), flag rules; 15 unit tests
- Security: docLink restricted to http(s); BQ-correct backslash escaping (note: sanitize.js escapeBqString quote-doubling bug — separate follow-up)

Spec: docs/superpowers/specs/2026-07-13-call-prep-design.md
Plan: docs/superpowers/plans/2026-07-14-call-prep.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)