### PR TITLE
feat(call-prep): dossier redesign — situation body, session timeline, cases

### DIFF
--- a/builder/index.html
+++ b/builder/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Method — Explorer</title>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400&display=swap" rel="stylesheet" />
   <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 <body>

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -10,6 +10,7 @@ import { queryBqWithRetry } from './bigquery.js';
 
 export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
 export const TIME_TRACKING_TABLE = '`project-for-method-dw.revenue.TimeTracking`';
+export const CASES_TABLE = '`project-for-method-dw.revenue.Cases`';
 
 export function buildConsultantsSql() {
   return `
@@ -70,6 +71,26 @@ export function buildAccountSessionsSql(recordId) {
     ORDER BY TxnDate`;
 }
 
+// Case history from revenue.Cases, keyed on MethodCompanyAccountRecordID.
+// CaseSubject is often null while Subject carries the title — coalesce.
+export function buildAccountCasesSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT
+      RecordID,
+      CaseStatus,
+      CasePriority,
+      COALESCE(CaseSubject, Subject) AS subject,
+      CreatedDate,
+      ClosedDate,
+      ContactName
+    FROM ${CASES_TABLE}
+    WHERE MethodCompanyAccountRecordID = ${id}
+      AND IsDeleted = FALSE
+    ORDER BY CreatedDate DESC
+    LIMIT 25`;
+}
+
 const toInt = (v, fallback = null) => (v == null || v === '' ? fallback : parseInt(v, 10));
 const toFloat = (v) => (v == null || v === '' ? null : parseFloat(v));
 const toBool = (v) => v === true || v === 'true';
@@ -124,6 +145,21 @@ export function normalizeSessionRow(row) {
   };
 }
 
+/** Convert a raw Cases row into a typed camelCase case. */
+export function normalizeCaseRow(row) {
+  const status = toStr(row.CaseStatus);
+  return {
+    recordId: toInt(row.RecordID),
+    status,
+    isOpen: !!status && status.toLowerCase() !== 'closed',
+    priority: toStr(row.CasePriority),
+    subject: toStr(row.subject),
+    createdDate: toStr(row.CreatedDate)?.slice(0, 10) ?? null,
+    closedDate: toStr(row.ClosedDate)?.slice(0, 10) ?? null,
+    contactName: toStr(row.ContactName),
+  };
+}
+
 const STALE_SESSION_DAYS = 30;
 const MS_PER_DAY = 86400000;
 
@@ -166,4 +202,9 @@ export async function fetchAccountSnapshots(recordId, { query = queryBqWithRetry
 export async function fetchAccountSessions(recordId, { query = queryBqWithRetry } = {}) {
   const { rows } = await query(buildAccountSessionsSql(recordId));
   return rows.map(normalizeSessionRow);
+}
+
+export async function fetchAccountCases(recordId, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildAccountCasesSql(recordId));
+  return rows.map(normalizeCaseRow);
 }

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -9,6 +9,7 @@ import { validateInt } from './sanitize.js';
 import { queryBqWithRetry } from './bigquery.js';
 
 export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
+export const TIME_TRACKING_TABLE = '`project-for-method-dw.revenue.TimeTracking`';
 
 export function buildConsultantsSql() {
   return `
@@ -47,6 +48,26 @@ export function buildAccountSnapshotsSql(recordId) {
     FROM ${CALL_PREP_TABLE}
     WHERE account_record_id = ${id}
     ORDER BY snapshot_date DESC`;
+}
+
+// Session history for the account's timeline. TimeTracking keys to the account
+// via MethodCompanyAccountRecordID (= snapshots.account_record_id). Notes are
+// full call write-ups; cap length so a chatty account doesn't bloat the payload.
+export function buildAccountSessionsSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT
+      TxnDate,
+      MethodSupportType,
+      BillableStatus,
+      IsDemo,
+      DurationHours,
+      AssignedToRecordID,
+      SUBSTR(Notes, 0, 4000) AS Notes
+    FROM ${TIME_TRACKING_TABLE}
+    WHERE MethodCompanyAccountRecordID = ${id}
+      AND IsDeleted = FALSE
+    ORDER BY TxnDate`;
 }
 
 const toInt = (v, fallback = null) => (v == null || v === '' ? fallback : parseInt(v, 10));
@@ -90,6 +111,19 @@ export function normalizeSnapshotRow(row) {
   };
 }
 
+/** Convert a raw TimeTracking row into a typed camelCase session. */
+export function normalizeSessionRow(row) {
+  return {
+    date: toStr(row.TxnDate),
+    supportType: toStr(row.MethodSupportType),
+    billable: toStr(row.BillableStatus),
+    isDemo: toBool(row.IsDemo),
+    durationHours: toFloat(row.DurationHours),
+    consultantId: toInt(row.AssignedToRecordID),
+    notes: toStr(row.Notes),
+  };
+}
+
 const STALE_SESSION_DAYS = 30;
 const MS_PER_DAY = 86400000;
 
@@ -127,4 +161,9 @@ export async function fetchBook(consultant, { query = queryBqWithRetry } = {}) {
 export async function fetchAccountSnapshots(recordId, { query = queryBqWithRetry } = {}) {
   const { rows } = await query(buildAccountSnapshotsSql(recordId));
   return rows.map(normalizeSnapshotRow);
+}
+
+export async function fetchAccountSessions(recordId, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildAccountSessionsSql(recordId));
+  return rows.map(normalizeSessionRow);
 }

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -1,43 +1,106 @@
 // Call Prep — account snapshot. Route: #/call-prep/account/:recordId
-// The page Slack deep-links to. Renders the latest snapshot natively;
-// a date selector exposes history. Narrative lives only in the Google
-// Doc until upstream lands it in BQ — we link out via doc_link.
+// The page Slack deep-links to. Rendered as a one-page pre-call brief: the
+// dep_signals prose is the body; sync/time/cases are a supporting vitals band.
+// All content comes from call_prep.snapshots in BigQuery — no doc read.
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { fetchAccountSnapshots } from '../lib/callPrep';
+import { fetchAccountSnapshots, computeFlags } from '../lib/callPrep';
+
+const PAPER = '#faf8f3';
+const INK = '#1c1a15';
+const MUTE = '#6f6a5d';
+const FAINT = '#a8a294';
+const RULE = '#e6e1d5';
+const ACCENT = '#1b5e43';
+const AMBER = '#a85a1a';
 
 const s = {
-  wrap: { maxWidth: 760, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
-  crumb: { fontSize: 13, color: '#059669', cursor: 'pointer', marginBottom: 16, display: 'inline-block' },
-  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 },
-  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a' },
-  sub: { fontSize: 13, color: '#6b7280', marginBottom: 24 },
-  select: { fontSize: 13, padding: '4px 8px', borderRadius: 6, border: '1px solid #e2e5e9' },
-  section: { marginBottom: 24 },
-  sectionTitle: {
-    fontSize: 10, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase',
-    color: '#8a9099', fontFamily: "'JetBrains Mono', monospace", marginBottom: 10,
+  stage: { background: PAPER, minHeight: '100%', padding: '32px 20px 72px', fontFamily: "'DM Sans', sans-serif" },
+  sheet: {
+    maxWidth: 720, margin: '0 auto', background: '#fffdf8',
+    border: `1px solid ${RULE}`, borderTop: `3px solid ${ACCENT}`,
+    borderRadius: 3, padding: '30px 40px 40px',
+    boxShadow: '0 1px 2px rgba(28,26,21,.04), 0 12px 34px -18px rgba(28,26,21,.22)',
   },
-  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 },
-  cell: { background: '#fff', border: '1px solid #e2e5e9', borderRadius: 8, padding: '10px 14px' },
-  cellLabel: { fontSize: 11, color: '#8a9099', marginBottom: 2 },
-  cellValue: { fontSize: 15, fontWeight: 600, color: '#1a1a1a' },
-  signal: {
-    display: 'inline-block', fontSize: 12, color: '#1d4ed8', background: '#eff6ff',
-    border: '1px solid #bfdbfe', borderRadius: 4, padding: '3px 10px', margin: '0 6px 6px 0',
+  topRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 26 },
+  crumb: { fontSize: 12.5, color: ACCENT, cursor: 'pointer', fontWeight: 500, textDecoration: 'none' },
+  select: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5, padding: '4px 8px',
+    borderRadius: 4, border: `1px solid ${RULE}`, background: PAPER, color: INK, cursor: 'pointer',
   },
-  docBtn: {
-    display: 'inline-block', padding: '8px 18px', background: '#059669', color: '#fff',
-    borderRadius: 6, fontSize: 13, fontWeight: 600, textDecoration: 'none',
+  dateStamp: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5, color: FAINT, letterSpacing: '.04em' },
+  kicker: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600,
+    letterSpacing: '.22em', textTransform: 'uppercase', color: ACCENT, marginBottom: 12,
   },
-  note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
-  error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+  title: {
+    fontFamily: "'Fraunces', serif", fontOpticalSizing: 'auto', fontWeight: 600,
+    fontSize: 40, lineHeight: 1.04, letterSpacing: '-.01em', color: INK, margin: '0 0 14px',
+  },
+  identity: { fontSize: 13.5, color: MUTE, lineHeight: 1.5, marginBottom: 14 },
+  identityStrong: { color: INK, fontWeight: 600 },
+  model: {
+    fontFamily: "'Fraunces', serif", fontStyle: 'italic', fontWeight: 400, fontSize: 17,
+    lineHeight: 1.5, color: '#39352b', margin: '0 0 4px', paddingLeft: 15,
+    borderLeft: `2px solid ${ACCENT}`,
+  },
+  alertRow: { display: 'flex', flexWrap: 'wrap', gap: 8, margin: '22px 0 4px' },
+  alert: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.02em',
+    color: AMBER, background: '#fbf1e4', border: '1px solid #edd6b8', borderRadius: 3, padding: '4px 9px',
+  },
+  rule: { border: 0, borderTop: `1px solid ${RULE}`, margin: '26px 0' },
+  bodyLabel: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600,
+    letterSpacing: '.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 16,
+  },
+  brief: { listStyle: 'none', margin: 0, padding: 0 },
+  briefItem: {
+    position: 'relative', paddingLeft: 24, marginBottom: 15,
+    fontSize: 15.5, lineHeight: 1.62, color: '#2c2921', maxWidth: 620,
+  },
+  briefMark: { position: 'absolute', left: 2, top: 10, width: 7, height: 7, borderRadius: '50%', background: ACCENT, opacity: .85 },
+  empty: { fontSize: 14, color: MUTE, fontStyle: 'italic' },
+  vitals: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '18px 24px' },
+  vital: {},
+  vitalLabel: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
+    letterSpacing: '.1em', textTransform: 'uppercase', color: FAINT, marginBottom: 5,
+  },
+  vitalValue: { fontSize: 16, fontWeight: 600, color: INK, lineHeight: 1.25 },
+  vitalSub: { fontSize: 11.5, color: MUTE, marginTop: 2 },
+  footer: {
+    marginTop: 30, paddingTop: 16, borderTop: `1px solid ${RULE}`,
+    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 8,
+  },
+  footerMeta: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: FAINT, letterSpacing: '.03em' },
+  sourceLink: { fontSize: 12, color: MUTE, textDecoration: 'none', borderBottom: `1px solid ${RULE}` },
+  center: { maxWidth: 720, margin: '0 auto', padding: '60px 24px', textAlign: 'center', color: MUTE, fontSize: 14 },
+  errorTxt: { color: '#b91c1c' },
 };
 
-const Cell = ({ label, value }) => (
-  <div style={s.cell}>
-    <div style={s.cellLabel}>{label}</div>
-    <div style={s.cellValue}>{value ?? '—'}</div>
+const CSS = `
+@keyframes cpRise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+.cp-rise { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
+.cp-brief-item { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
+.cp-crumb:hover { text-decoration: underline; }
+.cp-source:hover { color: ${ACCENT}; border-color: ${ACCENT}; }
+`;
+
+function ageLabel(months) {
+  if (months == null) return null;
+  const m = Math.round(months);
+  if (m < 12) return `${m}-month customer`;
+  const y = Math.floor(m / 12);
+  const rem = m % 12;
+  return rem ? `${y}yr ${rem}mo customer` : `${y}-year customer`;
+}
+
+const Vital = ({ label, value, sub, tone }) => (
+  <div style={s.vital}>
+    <div style={s.vitalLabel}>{label}</div>
+    <div style={{ ...s.vitalValue, ...(tone === 'warn' ? { color: AMBER } : null) }}>{value ?? '—'}</div>
+    {sub ? <div style={s.vitalSub}>{sub}</div> : null}
   </div>
 );
 
@@ -64,98 +127,126 @@ export default function CallPrepAccount() {
     return history.find((h) => h.snapshotDate === selectedDate) || history[0];
   }, [history, selectedDate]);
 
-  if (error) return <div style={s.wrap}><div style={s.error}>Couldn’t load snapshot: {error}</div></div>;
-  if (!history) return <div style={s.wrap}><div style={s.note}>Loading snapshot…</div></div>;
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const flags = useMemo(() => (snap ? computeFlags(snap, todayIso) : []), [snap, todayIso]);
+
+  if (error) {
+    return <div style={s.stage}><div style={s.center}><span style={s.errorTxt}>Couldn’t load snapshot: {error}</span></div></div>;
+  }
+  if (!history) return <div style={s.stage}><div style={s.center}>Loading brief…</div></div>;
   if (!history.length) {
     return (
-      <div style={s.wrap}>
-        <span style={s.crumb} onClick={() => navigate('/call-prep')}>← Call Prep</span>
-        <div style={s.note}>No snapshots exist for account {recordId} yet.</div>
+      <div style={s.stage}>
+        <div style={s.center}>
+          <a style={s.crumb} className="cp-crumb" onClick={() => navigate('/call-prep')}>← Call Prep</a>
+          <p style={{ marginTop: 16 }}>No snapshots exist for account {recordId} yet.</p>
+        </div>
       </div>
     );
   }
 
+  const industry = [snap.industryL1, snap.industryL2, snap.industryL3].filter(Boolean).join(' › ');
+  const age = ageLabel(snap.accountAgeMonths);
+  const syncWarn = (snap.syncStatus && snap.syncStatus !== 'healthy') || snap.syncFailCount > 0;
+
   return (
-    <div style={s.wrap}>
-      <span style={s.crumb} onClick={() => navigate(`/call-prep/${encodeURIComponent(snap.consultant || '')}`)}>
-        ← {snap.consultant}’s book
-      </span>
-      <div style={s.head}>
-        <h1 style={s.title}>{snap.accountName ?? '—'}</h1>
-        {history.length > 1 ? (
-          <select
-            style={s.select}
-            value={snap.snapshotDate}
-            onChange={(e) => setSelectedDate(e.target.value)}
+    <div style={s.stage}>
+      <style>{CSS}</style>
+      <div style={s.sheet}>
+        <div style={s.topRow}>
+          <a
+            style={s.crumb}
+            className="cp-crumb"
+            onClick={() => navigate(`/call-prep/${encodeURIComponent(snap.consultant || '')}`)}
           >
-            {history.map((h) => (
-              <option key={h.snapshotDate} value={h.snapshotDate}>{h.snapshotDate}</option>
-            ))}
-          </select>
-        ) : (
-          <span style={{ fontSize: 13, color: '#6b7280' }}>{snap.snapshotDate}</span>
+            ← {snap.consultant || 'Call Prep'}{snap.consultant ? '’s book' : ''}
+          </a>
+          {history.length > 1 ? (
+            <select style={s.select} value={snap.snapshotDate} onChange={(e) => setSelectedDate(e.target.value)}>
+              {history.map((h) => (
+                <option key={h.snapshotDate} value={h.snapshotDate}>{h.snapshotDate}</option>
+              ))}
+            </select>
+          ) : (
+            <span style={s.dateStamp}>{snap.snapshotDate}</span>
+          )}
+        </div>
+
+        <div className="cp-rise" style={{ animationDelay: '0ms' }}>
+          <div style={s.kicker}>{[snap.callType, 'Pre-call brief'].filter(Boolean).join(' · ')}</div>
+        </div>
+        <h1 className="cp-rise" style={{ ...s.title, animationDelay: '40ms' }}>{snap.accountName ?? '—'}</h1>
+
+        <div className="cp-rise" style={{ animationDelay: '90ms' }}>
+          <div style={s.identity}>
+            {industry ? <span style={s.identityStrong}>{industry}</span> : null}
+            {industry && (age || snap.signupDate) ? '  ·  ' : ''}
+            {age}
+            {age && snap.signupDate ? ' ' : ''}
+            {snap.signupDate ? <span>(since {snap.signupDate})</span> : null}
+            {snap.depEnrolled ? '  ·  DEP enrolled' : ''}
+            {snap.multiEntityParentName ? `  ·  child of ${snap.multiEntityParentName}` : ''}
+          </div>
+          {snap.operatingModel ? <p style={s.model}>{snap.operatingModel}</p> : null}
+        </div>
+
+        {flags.length > 0 && (
+          <div className="cp-rise" style={{ ...s.alertRow, animationDelay: '140ms' }}>
+            {flags.map((f) => <span key={f} style={s.alert}>{f}</span>)}
+          </div>
         )}
-      </div>
-      <p style={s.sub}>
-        {snap.callType} · {snap.consultant} · account #{snap.accountRecordId}
-      </p>
 
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Account</div>
-        <div style={s.grid}>
-          <Cell label="Signup date" value={snap.signupDate} />
-          <Cell label="Age (months)" value={snap.accountAgeMonths != null ? snap.accountAgeMonths.toFixed(1) : null} />
-          <Cell label="DEP enrolled" value={snap.depEnrolled ? 'yes' : 'no'} />
-          <Cell label="Parent" value={snap.multiEntityParentName} />
+        <hr style={s.rule} />
+
+        <div style={s.bodyLabel}>What’s going on</div>
+        {snap.depSignals.length > 0 ? (
+          <ul style={s.brief}>
+            {snap.depSignals.map((sig, i) => (
+              <li key={sig} className="cp-brief-item" style={{ ...s.briefItem, animationDelay: `${180 + i * 55}ms` }}>
+                <span style={s.briefMark} />
+                {sig}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p style={s.empty}>No prep notes recorded for this snapshot.</p>
+        )}
+
+        <hr style={s.rule} />
+
+        <div style={s.vitals}>
+          <Vital
+            label="Sync"
+            value={snap.syncStatus || '—'}
+            sub={snap.syncFailCount > 0 ? `${snap.syncFailCount} recent failure${snap.syncFailCount === 1 ? '' : 's'}` : null}
+            tone={syncWarn ? 'warn' : null}
+          />
+          <Vital
+            label="Time tracked"
+            value={snap.ttTotalHours != null ? `${snap.ttTotalHours} hrs` : '—'}
+            sub={[
+              snap.ttSessionCount != null ? `${snap.ttSessionCount} sessions` : null,
+              snap.ttLastSessionDate ? `last ${snap.ttLastSessionDate}` : null,
+            ].filter(Boolean).join(' · ') || null}
+          />
+          <Vital
+            label="Open cases"
+            value={snap.casesOpenCount}
+            sub={snap.casesClosed90dCount != null ? `${snap.casesClosed90dCount} closed in 90d` : null}
+            tone={snap.casesOpenCount > 0 ? 'warn' : null}
+          />
         </div>
-      </div>
 
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Sync</div>
-        <div style={s.grid}>
-          <Cell label="Status" value={snap.syncStatus} />
-          <Cell label="Fail count" value={snap.syncFailCount} />
+        <div style={s.footer}>
+          <span style={s.footerMeta}>
+            Prepared for {snap.consultant || '—'} · account #{snap.accountRecordId} · snapshot {snap.snapshotDate}
+          </span>
+          {snap.docLink ? (
+            <a style={s.sourceLink} className="cp-source" href={snap.docLink} target="_blank" rel="noreferrer">
+              source document ↗
+            </a>
+          ) : null}
         </div>
-      </div>
-
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Time tracking</div>
-        <div style={s.grid}>
-          <Cell label="Total hours" value={snap.ttTotalHours} />
-          <Cell label="Sessions" value={snap.ttSessionCount} />
-          <Cell label="Last session" value={snap.ttLastSessionDate} />
-        </div>
-      </div>
-
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Cases</div>
-        <div style={s.grid}>
-          <Cell label="Open" value={snap.casesOpenCount} />
-          <Cell label="Closed (90d)" value={snap.casesClosed90dCount} />
-        </div>
-      </div>
-
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Classification</div>
-        <div style={s.grid}>
-          <Cell label="Industry" value={[snap.industryL1, snap.industryL2, snap.industryL3].filter(Boolean).join(' › ') || null} />
-          <Cell label="Operating model" value={snap.operatingModel} />
-          <Cell label="Confidence" value={snap.bqConfidence != null ? `${Math.round(snap.bqConfidence * 100)}%` : null} />
-        </div>
-      </div>
-
-      {snap.depSignals.length > 0 && (
-        <div style={s.section}>
-          <div style={s.sectionTitle}>DEP signals</div>
-          <div>{snap.depSignals.map((sig) => <span key={sig} style={s.signal}>{sig}</span>)}</div>
-        </div>
-      )}
-
-      <div style={s.section}>
-        <div style={s.sectionTitle}>Prep write-up</div>
-        {snap.docLink
-          ? <a href={snap.docLink} target="_blank" rel="noreferrer" style={s.docBtn}>Open prep doc ↗</a>
-          : <span style={{ fontSize: 13, color: '#6b7280' }}>Write-up unavailable for this snapshot.</span>}
       </div>
     </div>
   );

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -5,7 +5,7 @@
 // revenue.TimeTracking. All content is sourced from BigQuery — no doc read.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { fetchAccountSnapshots, fetchAccountSessions, computeFlags } from '../lib/callPrep';
+import { fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases, computeFlags } from '../lib/callPrep';
 
 const PAPER = '#faf8f3';
 const INK = '#1c1a15';
@@ -91,6 +91,16 @@ const s = {
   },
   expandHint: { fontSize: 11.5, color: ACCENT, marginTop: 3 },
 
+  // Cases
+  caseRow: { padding: '12px 0', borderBottom: `1px solid ${RULE}` },
+  caseTop: { display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' },
+  caseSubject: { fontSize: 14.5, fontWeight: 600, color: INK },
+  caseBadge: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 9.5, fontWeight: 600, letterSpacing: '.05em',
+    textTransform: 'uppercase', borderRadius: 3, padding: '2px 7px',
+  },
+  caseMeta: { fontSize: 12, color: MUTE, marginTop: 3 },
+
   // Details grid
   grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '16px 22px' },
   dLabel: {
@@ -164,19 +174,25 @@ export default function CallPrepAccount() {
   const [sessions, setSessions] = useState(null);
   const [sessionsErr, setSessionsErr] = useState('');
   const [openEvent, setOpenEvent] = useState(null);
+  const [cases, setCases] = useState(null);
+  const [casesErr, setCasesErr] = useState('');
   const sheetRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     setHistory(null); setSelectedDate(null); setError('');
     setSessions(null); setSessionsErr(''); setOpenEvent(null);
+    setCases(null); setCasesErr('');
     fetchAccountSnapshots(recordId)
       .then((h) => { if (!cancelled) setHistory(h); })
       .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
-    // Timeline loads independently — a TimeTracking failure must not blank the brief.
+    // Timeline and cases load independently — a CRM-table failure must not blank the brief.
     fetchAccountSessions(recordId)
       .then((rows) => { if (!cancelled) setSessions(rows); })
       .catch((e) => { if (!cancelled) setSessionsErr(e?.message || String(e)); });
+    fetchAccountCases(recordId)
+      .then((rows) => { if (!cancelled) setCases(rows); })
+      .catch((e) => { if (!cancelled) setCasesErr(e?.message || String(e)); });
     return () => { cancelled = true; };
   }, [recordId]);
 
@@ -260,6 +276,7 @@ export default function CallPrepAccount() {
         <nav style={s.nav}>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('situation')}>Situation</a>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('timeline')}>Timeline</a>
+          <a className="cp-chip" style={s.navChip} onClick={() => jump('cases')}>Cases</a>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('details')}>Details</a>
         </nav>
 
@@ -324,6 +341,36 @@ export default function CallPrepAccount() {
               })}
               {sessions.length === 0 && <li style={s.empty}>No sessions recorded yet.</li>}
             </ul>
+          )}
+        </section>
+
+        <section id="cases" style={s.section}>
+          <div style={s.bodyLabel}>Cases</div>
+          {casesErr ? (
+            <p style={s.timelineErr}>Couldn’t load cases.</p>
+          ) : cases == null ? (
+            <p style={s.timelineErr}>Loading cases…</p>
+          ) : cases.length === 0 ? (
+            <p style={s.empty}>No cases on record.</p>
+          ) : (
+            <div>
+              {cases.map((c) => (
+                <div key={c.recordId} style={s.caseRow}>
+                  <div style={s.caseTop}>
+                    <span style={s.caseSubject}>{c.subject ?? `Case #${c.recordId}`}</span>
+                    <span style={{ ...s.caseBadge, ...(c.isOpen ? { background: '#fbf1e4', color: AMBER } : { background: '#f1efe8', color: MUTE }) }}>
+                      {c.status || (c.isOpen ? 'Open' : 'Closed')}
+                    </span>
+                    {c.priority ? <span style={{ ...s.caseBadge, background: '#f1efe8', color: MUTE }}>{c.priority}</span> : null}
+                  </div>
+                  <div style={s.caseMeta}>
+                    #{c.recordId} · opened {c.createdDate}
+                    {c.closedDate ? ` · closed ${c.closedDate}` : ''}
+                    {c.contactName ? ` · ${c.contactName}` : ''}
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
         </section>
 

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -1,10 +1,11 @@
 // Call Prep — account snapshot. Route: #/call-prep/account/:recordId
-// The page Slack deep-links to. Rendered as a one-page pre-call brief: the
-// dep_signals prose is the body; sync/time/cases are a supporting vitals band.
-// All content comes from call_prep.snapshots in BigQuery — no doc read.
-import { useEffect, useMemo, useState } from 'react';
+// A one-page pre-call brief: dep_signals prose is the body; a jump-nav lets
+// the consultant snap between Situation / Timeline / Details without hiding
+// anything. The timeline is the account's real session history from
+// revenue.TimeTracking. All content is sourced from BigQuery — no doc read.
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { fetchAccountSnapshots, computeFlags } from '../lib/callPrep';
+import { fetchAccountSnapshots, fetchAccountSessions, computeFlags } from '../lib/callPrep';
 
 const PAPER = '#faf8f3';
 const INK = '#1c1a15';
@@ -49,7 +50,17 @@ const s = {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.02em',
     color: AMBER, background: '#fbf1e4', border: '1px solid #edd6b8', borderRadius: 3, padding: '4px 9px',
   },
-  rule: { border: 0, borderTop: `1px solid ${RULE}`, margin: '26px 0' },
+  nav: {
+    position: 'sticky', top: 0, zIndex: 5, display: 'flex', gap: 6, flexWrap: 'wrap',
+    margin: '24px 0 4px', padding: '10px 0', background: 'rgba(255,253,248,.92)',
+    backdropFilter: 'blur(4px)', borderBottom: `1px solid ${RULE}`,
+  },
+  navChip: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.06em',
+    textTransform: 'uppercase', color: MUTE, background: PAPER, border: `1px solid ${RULE}`,
+    borderRadius: 999, padding: '5px 13px', cursor: 'pointer', textDecoration: 'none',
+  },
+  section: { scrollMarginTop: 56, paddingTop: 26 },
   bodyLabel: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600,
     letterSpacing: '.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 16,
@@ -61,30 +72,52 @@ const s = {
   },
   briefMark: { position: 'absolute', left: 2, top: 10, width: 7, height: 7, borderRadius: '50%', background: ACCENT, opacity: .85 },
   empty: { fontSize: 14, color: MUTE, fontStyle: 'italic' },
-  vitals: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '18px 24px' },
-  vital: {},
-  vitalLabel: {
-    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
-    letterSpacing: '.1em', textTransform: 'uppercase', color: FAINT, marginBottom: 5,
+
+  // Timeline
+  rail: { position: 'relative', margin: 0, padding: 0, listStyle: 'none' },
+  railLine: { position: 'absolute', left: 7, top: 6, bottom: 6, width: 2, background: RULE },
+  event: { position: 'relative', paddingLeft: 34, marginBottom: 20 },
+  dot: { position: 'absolute', left: 2, top: 3, width: 13, height: 13, borderRadius: '50%', border: `2px solid ${PAPER}`, boxSizing: 'border-box' },
+  eventHead: { display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap', cursor: 'pointer' },
+  eventDate: { fontFamily: "'JetBrains Mono', monospace", fontSize: 12, color: INK, fontWeight: 600 },
+  typeBadge: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600, letterSpacing: '.05em',
+    textTransform: 'uppercase', borderRadius: 3, padding: '2px 7px',
   },
-  vitalValue: { fontSize: 16, fontWeight: 600, color: INK, lineHeight: 1.25 },
-  vitalSub: { fontSize: 11.5, color: MUTE, marginTop: 2 },
+  eventMeta: { fontSize: 12, color: MUTE },
+  eventNotes: {
+    marginTop: 8, fontSize: 13.5, lineHeight: 1.55, color: '#3a362d', whiteSpace: 'pre-wrap',
+    background: PAPER, border: `1px solid ${RULE}`, borderRadius: 4, padding: '10px 13px', maxWidth: 600,
+  },
+  expandHint: { fontSize: 11.5, color: ACCENT, marginTop: 3 },
+
+  // Details grid
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '16px 22px' },
+  dLabel: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
+    letterSpacing: '.1em', textTransform: 'uppercase', color: FAINT, marginBottom: 4,
+  },
+  dValue: { fontSize: 14.5, fontWeight: 500, color: INK, lineHeight: 1.35 },
+  dValueWarn: { color: AMBER },
+
   footer: {
-    marginTop: 30, paddingTop: 16, borderTop: `1px solid ${RULE}`,
+    marginTop: 32, paddingTop: 16, borderTop: `1px solid ${RULE}`,
     display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 8,
   },
   footerMeta: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: FAINT, letterSpacing: '.03em' },
   sourceLink: { fontSize: 12, color: MUTE, textDecoration: 'none', borderBottom: `1px solid ${RULE}` },
   center: { maxWidth: 720, margin: '0 auto', padding: '60px 24px', textAlign: 'center', color: MUTE, fontSize: 14 },
   errorTxt: { color: '#b91c1c' },
+  timelineErr: { fontSize: 13, color: MUTE, fontStyle: 'italic' },
 };
 
 const CSS = `
 @keyframes cpRise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 .cp-rise { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
 .cp-brief-item { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
-.cp-crumb:hover { text-decoration: underline; }
-.cp-source:hover { color: ${ACCENT}; border-color: ${ACCENT}; }
+.cp-crumb:hover, .cp-source:hover { text-decoration: underline; }
+.cp-chip:hover { border-color: ${ACCENT}; color: ${ACCENT}; }
+.cp-event-head:hover .cp-date { color: ${ACCENT}; }
 `;
 
 function ageLabel(months) {
@@ -96,11 +129,29 @@ function ageLabel(months) {
   return rem ? `${y}yr ${rem}mo customer` : `${y}-year customer`;
 }
 
-const Vital = ({ label, value, sub, tone }) => (
-  <div style={s.vital}>
-    <div style={s.vitalLabel}>{label}</div>
-    <div style={{ ...s.vitalValue, ...(tone === 'warn' ? { color: AMBER } : null) }}>{value ?? '—'}</div>
-    {sub ? <div style={s.vitalSub}>{sub}</div> : null}
+// Session Notes start with a weekday-date header and a ==== rule — strip those
+// so the expanded note reads as the actual content.
+function cleanNotes(notes) {
+  if (!notes) return '';
+  return notes
+    .split('\n')
+    .filter((ln) => !/^=+$/.test(ln.trim()) && !/^[A-Za-z]+day,\s/.test(ln.trim()))
+    .join('\n')
+    .trim();
+}
+
+function sessionKind(sess) {
+  if (sess.isDemo) return { label: 'Demo', bg: '#eef2ff', fg: '#3730a3', dot: '#4f46e5' };
+  const t = (sess.supportType || '').toLowerCase();
+  if (t === 'free') return { label: 'Free hour', bg: '#ecfdf3', fg: ACCENT, dot: ACCENT };
+  if (t.includes('pay')) return { label: 'Pay-per-use', bg: '#fbf1e4', fg: AMBER, dot: AMBER };
+  return { label: sess.supportType || 'Session', bg: '#f1efe8', fg: MUTE, dot: FAINT };
+}
+
+const Detail = ({ label, value, warn }) => (
+  <div>
+    <div style={s.dLabel}>{label}</div>
+    <div style={{ ...s.dValue, ...(warn ? s.dValueWarn : null) }}>{value ?? '—'}</div>
   </div>
 );
 
@@ -110,15 +161,22 @@ export default function CallPrepAccount() {
   const [history, setHistory] = useState(null);
   const [error, setError] = useState('');
   const [selectedDate, setSelectedDate] = useState(null);
+  const [sessions, setSessions] = useState(null);
+  const [sessionsErr, setSessionsErr] = useState('');
+  const [openEvent, setOpenEvent] = useState(null);
+  const sheetRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
-    setHistory(null);
-    setSelectedDate(null);
-    setError('');
+    setHistory(null); setSelectedDate(null); setError('');
+    setSessions(null); setSessionsErr(''); setOpenEvent(null);
     fetchAccountSnapshots(recordId)
       .then((h) => { if (!cancelled) setHistory(h); })
       .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
+    // Timeline loads independently — a TimeTracking failure must not blank the brief.
+    fetchAccountSessions(recordId)
+      .then((rows) => { if (!cancelled) setSessions(rows); })
+      .catch((e) => { if (!cancelled) setSessionsErr(e?.message || String(e)); });
     return () => { cancelled = true; };
   }, [recordId]);
 
@@ -129,6 +187,11 @@ export default function CallPrepAccount() {
 
   const todayIso = new Date().toISOString().slice(0, 10);
   const flags = useMemo(() => (snap ? computeFlags(snap, todayIso) : []), [snap, todayIso]);
+
+  const jump = (id) => {
+    const el = sheetRef.current?.querySelector(`#${id}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   if (error) {
     return <div style={s.stage}><div style={s.center}><span style={s.errorTxt}>Couldn’t load snapshot: {error}</span></div></div>;
@@ -152,7 +215,7 @@ export default function CallPrepAccount() {
   return (
     <div style={s.stage}>
       <style>{CSS}</style>
-      <div style={s.sheet}>
+      <div style={s.sheet} ref={sheetRef}>
         <div style={s.topRow}>
           <a
             style={s.crumb}
@@ -172,9 +235,7 @@ export default function CallPrepAccount() {
           )}
         </div>
 
-        <div className="cp-rise" style={{ animationDelay: '0ms' }}>
-          <div style={s.kicker}>{[snap.callType, 'Pre-call brief'].filter(Boolean).join(' · ')}</div>
-        </div>
+        <div className="cp-rise"><div style={s.kicker}>{[snap.callType, 'Pre-call brief'].filter(Boolean).join(' · ')}</div></div>
         <h1 className="cp-rise" style={{ ...s.title, animationDelay: '40ms' }}>{snap.accountName ?? '—'}</h1>
 
         <div className="cp-rise" style={{ animationDelay: '90ms' }}>
@@ -196,46 +257,95 @@ export default function CallPrepAccount() {
           </div>
         )}
 
-        <hr style={s.rule} />
+        <nav style={s.nav}>
+          <a className="cp-chip" style={s.navChip} onClick={() => jump('situation')}>Situation</a>
+          <a className="cp-chip" style={s.navChip} onClick={() => jump('timeline')}>Timeline</a>
+          <a className="cp-chip" style={s.navChip} onClick={() => jump('details')}>Details</a>
+        </nav>
 
-        <div style={s.bodyLabel}>What’s going on</div>
-        {snap.depSignals.length > 0 ? (
-          <ul style={s.brief}>
-            {snap.depSignals.map((sig, i) => (
-              <li key={sig} className="cp-brief-item" style={{ ...s.briefItem, animationDelay: `${180 + i * 55}ms` }}>
-                <span style={s.briefMark} />
-                {sig}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p style={s.empty}>No prep notes recorded for this snapshot.</p>
-        )}
+        <section id="situation" style={s.section}>
+          <div style={s.bodyLabel}>What’s going on</div>
+          {snap.depSignals.length > 0 ? (
+            <ul style={s.brief}>
+              {snap.depSignals.map((sig, i) => (
+                <li key={sig} className="cp-brief-item" style={{ ...s.briefItem, animationDelay: `${i * 45}ms` }}>
+                  <span style={s.briefMark} />
+                  {sig}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p style={s.empty}>No prep notes recorded for this snapshot.</p>
+          )}
+        </section>
 
-        <hr style={s.rule} />
+        <section id="timeline" style={s.section}>
+          <div style={s.bodyLabel}>History</div>
+          {sessionsErr ? (
+            <p style={s.timelineErr}>Couldn’t load session history.</p>
+          ) : sessions == null ? (
+            <p style={s.timelineErr}>Loading history…</p>
+          ) : (
+            <ul style={s.rail}>
+              <div style={s.railLine} />
+              {snap.signupDate && (
+                <li style={s.event}>
+                  <span style={{ ...s.dot, background: INK }} />
+                  <div style={s.eventHead}>
+                    <span style={s.eventDate}>{snap.signupDate}</span>
+                    <span style={{ ...s.typeBadge, background: '#efece3', color: INK }}>Signed up</span>
+                  </div>
+                </li>
+              )}
+              {sessions.map((sess, i) => {
+                const kind = sessionKind(sess);
+                const key = `${sess.date}-${i}`;
+                const isThisCall = sess.date === snap.snapshotDate;
+                const body = cleanNotes(sess.notes);
+                const open = openEvent === key;
+                return (
+                  <li key={key} style={s.event}>
+                    <span style={{ ...s.dot, background: kind.dot }} />
+                    <div className="cp-event-head" style={s.eventHead} onClick={() => setOpenEvent(open ? null : key)}>
+                      <span className="cp-date" style={s.eventDate}>{sess.date}</span>
+                      <span style={{ ...s.typeBadge, background: kind.bg, color: kind.fg }}>{kind.label}</span>
+                      <span style={s.eventMeta}>
+                        {sess.durationHours != null ? `${sess.durationHours} hr` : ''}
+                        {isThisCall ? '  ·  this call’s day' : ''}
+                      </span>
+                    </div>
+                    {body ? (
+                      open
+                        ? <div style={s.eventNotes}>{body}</div>
+                        : <div style={s.expandHint}>click to read notes →</div>
+                    ) : null}
+                  </li>
+                );
+              })}
+              {sessions.length === 0 && <li style={s.empty}>No sessions recorded yet.</li>}
+            </ul>
+          )}
+        </section>
 
-        <div style={s.vitals}>
-          <Vital
-            label="Sync"
-            value={snap.syncStatus || '—'}
-            sub={snap.syncFailCount > 0 ? `${snap.syncFailCount} recent failure${snap.syncFailCount === 1 ? '' : 's'}` : null}
-            tone={syncWarn ? 'warn' : null}
-          />
-          <Vital
-            label="Time tracked"
-            value={snap.ttTotalHours != null ? `${snap.ttTotalHours} hrs` : '—'}
-            sub={[
-              snap.ttSessionCount != null ? `${snap.ttSessionCount} sessions` : null,
-              snap.ttLastSessionDate ? `last ${snap.ttLastSessionDate}` : null,
-            ].filter(Boolean).join(' · ') || null}
-          />
-          <Vital
-            label="Open cases"
-            value={snap.casesOpenCount}
-            sub={snap.casesClosed90dCount != null ? `${snap.casesClosed90dCount} closed in 90d` : null}
-            tone={snap.casesOpenCount > 0 ? 'warn' : null}
-          />
-        </div>
+        <section id="details" style={s.section}>
+          <div style={s.bodyLabel}>Details</div>
+          <div style={s.grid}>
+            <Detail label="Sync status" value={snap.syncStatus} warn={syncWarn} />
+            <Detail label="Sync failures" value={snap.syncFailCount} warn={snap.syncFailCount > 0} />
+            <Detail label="Time tracked" value={snap.ttTotalHours != null ? `${snap.ttTotalHours} hrs` : null} />
+            <Detail label="Sessions (snapshot)" value={snap.ttSessionCount} />
+            <Detail label="Last session" value={snap.ttLastSessionDate} />
+            <Detail label="Open cases" value={snap.casesOpenCount} warn={snap.casesOpenCount > 0} />
+            <Detail label="Closed cases (90d)" value={snap.casesClosed90dCount} />
+            <Detail label="Signup date" value={snap.signupDate} />
+            <Detail label="Account age" value={snap.accountAgeMonths != null ? `${snap.accountAgeMonths.toFixed(1)} mo` : null} />
+            <Detail label="DEP enrolled" value={snap.depEnrolled ? 'yes' : 'no'} />
+            {snap.multiEntityParentName ? <Detail label="Parent entity" value={snap.multiEntityParentName} /> : null}
+            <Detail label="Industry" value={industry || null} />
+            <Detail label="Operating model" value={snap.operatingModel} />
+            {snap.bqConfidence != null ? <Detail label="Classifier confidence" value={`${Math.round(snap.bqConfidence * 100)}%`} /> : null}
+          </div>
+        </section>
 
         <div style={s.footer}>
           <span style={s.footerMeta}>

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -1,12 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import {
   CALL_PREP_TABLE,
+  TIME_TRACKING_TABLE,
   buildConsultantsSql,
   buildBookSql,
   buildAccountSnapshotsSql,
+  buildAccountSessionsSql,
 } from '../../src/lib/callPrep.js';
-import { normalizeSnapshotRow, computeFlags } from '../../src/lib/callPrep.js';
-import { fetchConsultants, fetchBook, fetchAccountSnapshots } from '../../src/lib/callPrep.js';
+import { normalizeSnapshotRow, normalizeSessionRow, computeFlags } from '../../src/lib/callPrep.js';
+import { fetchConsultants, fetchBook, fetchAccountSnapshots, fetchAccountSessions } from '../../src/lib/callPrep.js';
 
 describe('buildConsultantsSql', () => {
   it('aggregates consultants from the snapshots table', () => {
@@ -41,6 +43,34 @@ describe('buildAccountSnapshotsSql', () => {
   it('rejects non-integer record ids', () => {
     expect(() => buildAccountSnapshotsSql('141376; DROP TABLE x')).toThrow();
     expect(() => buildAccountSnapshotsSql('abc')).toThrow();
+  });
+});
+
+describe('buildAccountSessionsSql', () => {
+  it('queries TimeTracking by account, oldest first, excluding deleted', () => {
+    const sql = buildAccountSessionsSql('141376');
+    expect(sql).toContain(TIME_TRACKING_TABLE);
+    expect(sql).toContain('MethodCompanyAccountRecordID = 141376');
+    expect(sql).toMatch(/IsDeleted = FALSE/);
+    expect(sql).toMatch(/ORDER BY TxnDate/);
+  });
+
+  it('rejects non-integer record ids', () => {
+    expect(() => buildAccountSessionsSql('1; DROP TABLE x')).toThrow();
+    expect(() => buildAccountSessionsSql('abc')).toThrow();
+  });
+});
+
+describe('normalizeSessionRow', () => {
+  it('casts a TimeTracking row to a typed session', () => {
+    const s = normalizeSessionRow({
+      TxnDate: '2025-07-18', MethodSupportType: 'Free', BillableStatus: 'HasBeenBilled',
+      IsDemo: 'false', DurationHours: '1', AssignedToRecordID: '380', Notes: 'Kickoff call',
+    });
+    expect(s).toEqual({
+      date: '2025-07-18', supportType: 'Free', billable: 'HasBeenBilled',
+      isDemo: false, durationHours: 1, consultantId: 380, notes: 'Kickoff call',
+    });
   });
 });
 

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -2,13 +2,15 @@ import { describe, it, expect } from 'vitest';
 import {
   CALL_PREP_TABLE,
   TIME_TRACKING_TABLE,
+  CASES_TABLE,
   buildConsultantsSql,
   buildBookSql,
   buildAccountSnapshotsSql,
   buildAccountSessionsSql,
+  buildAccountCasesSql,
 } from '../../src/lib/callPrep.js';
-import { normalizeSnapshotRow, normalizeSessionRow, computeFlags } from '../../src/lib/callPrep.js';
-import { fetchConsultants, fetchBook, fetchAccountSnapshots, fetchAccountSessions } from '../../src/lib/callPrep.js';
+import { normalizeSnapshotRow, normalizeSessionRow, normalizeCaseRow, computeFlags } from '../../src/lib/callPrep.js';
+import { fetchConsultants, fetchBook, fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases } from '../../src/lib/callPrep.js';
 
 describe('buildConsultantsSql', () => {
   it('aggregates consultants from the snapshots table', () => {
@@ -71,6 +73,43 @@ describe('normalizeSessionRow', () => {
       date: '2025-07-18', supportType: 'Free', billable: 'HasBeenBilled',
       isDemo: false, durationHours: 1, consultantId: 380, notes: 'Kickoff call',
     });
+  });
+});
+
+describe('buildAccountCasesSql', () => {
+  it('queries Cases by account, newest first, excluding deleted', () => {
+    const sql = buildAccountCasesSql('90430');
+    expect(sql).toContain(CASES_TABLE);
+    expect(sql).toContain('MethodCompanyAccountRecordID = 90430');
+    expect(sql).toMatch(/IsDeleted = FALSE/);
+    expect(sql).toMatch(/ORDER BY CreatedDate DESC/);
+  });
+
+  it('rejects non-integer record ids', () => {
+    expect(() => buildAccountCasesSql('1 OR 1=1')).toThrow();
+    expect(() => buildAccountCasesSql('abc')).toThrow();
+  });
+});
+
+describe('normalizeCaseRow', () => {
+  it('casts a Cases row, derives isOpen, trims timestamps to dates', () => {
+    const c = normalizeCaseRow({
+      RecordID: '63114', CaseStatus: 'Closed', CasePriority: 'P2-Normal',
+      subject: 'Sync Engine Related - Credentials are not saving',
+      CreatedDate: '2025-08-14T14:48:04Z', ClosedDate: '2025-08-14T18:25:28Z', ContactName: 'Bill Paschick',
+    });
+    expect(c).toEqual({
+      recordId: 63114, status: 'Closed', isOpen: false, priority: 'P2-Normal',
+      subject: 'Sync Engine Related - Credentials are not saving',
+      createdDate: '2025-08-14', closedDate: '2025-08-14', contactName: 'Bill Paschick',
+    });
+  });
+
+  it('marks non-closed statuses open and tolerates nulls', () => {
+    const c = normalizeCaseRow({ RecordID: '40347', CaseStatus: 'Waiting on Jira', subject: null, CreatedDate: '2021-02-23T17:22:35Z' });
+    expect(c.isOpen).toBe(true);
+    expect(c.closedDate).toBe(null);
+    expect(c.subject).toBe(null);
   });
 });
 


### PR DESCRIPTION
Brings the 3 commits that landed after PR #38 merged, so the live brief matches the intended design (replaces the doc rather than showing a stat-tile dashboard).

- Redesign account page as a readable pre-call brief (Fraunces headline, dep_signals as the body, operating-model pull-quote, doc demoted to footer)
- Session timeline from revenue.TimeTracking (signup → free hour → PPU sessions, click-to-open notes) + sticky jump-nav (Situation / Timeline / Cases / Details)
- Cases section from revenue.Cases (live)

All reads are BigQuery. 22 unit tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)