### PR TITLE
feat(dbt): int_accounts — account-grain overview (MRR run-rate, licenses, health)

### DIFF
--- a/models/intermediate/_int_accounts.yml
+++ b/models/intermediate/_int_accounts.yml
@@ -1,0 +1,63 @@
+version: 2
+
+models:
+  - name: int_accounts
+    description: |
+      One row per Method account (account grain, key = account_record_id).
+      Current-state account attributes for operational lookup: SaaS run-rate,
+      user licenses, health score, pay type, active flag. entity_record_id
+      bridges to the entity-grain revenue models (int_customers,
+      int_customer_mrr) which key on EntityRecordID. Source: revenue.Account
+      (Alocet nightly mirror). Distinct grain from int_customers, which is
+      entity/customer grain and a monthly time series — this model is current
+      account state, one row per account.
+    config:
+      meta:
+        layer: intermediate
+        grain: account
+        owner: nic
+
+    columns:
+      - name: account_record_id
+        description: >
+          Account-level primary key. Equals Alocet CustomerMethodAccount.RecordID
+          and call_prep.snapshots.account_record_id — the join key for the call-prep
+          brief.
+        tests:
+          - unique
+          - not_null
+
+      - name: entity_record_id
+        description: >
+          Customer/entity key. Bridge to int_customers / int_customer_mrr, which
+          key on EntityRecordID. This was the missing link that blocked joining
+          account-grain call-prep data to the entity-grain revenue models.
+
+      - name: company_account
+        description: Subdomain-style account name (e.g. "wavedistro1").
+
+      - name: mrr_run_rate
+        description: >
+          Monthly SaaS run-rate proxy from Account.Custdatlastsaasamount (nightly
+          snapshot). Excludes prepay discount, portals, and overages. Directional
+          only — NOT recognized revenue and NOT board-grade MRR (canonical
+          recognized SaaS is TransLineFlattened.SaaSAmount). Use for operational
+          context on the account brief, not for revenue reporting.
+
+      - name: user_licenses
+        description: >
+          Paid user license count (Account.LicenseCount). Source contains
+          negatives (min observed -2) from credits/adjustments — guard with
+          NULLIF(GREATEST(user_licenses,0),0) before using as a ratio denominator.
+
+      - name: health_score
+        description: >
+          Customer health score 0–100 (Account.HealthScore). ~61% null across all
+          accounts, populated mainly on active accounts. Nullable by design — no
+          not_null test.
+
+      - name: is_active
+        description: Whether the account is active (has not cancelled).
+
+      - name: saas_pay_type
+        description: Billing type, e.g. Prepay or Monthly (Account.SaaSPayType).

--- a/models/intermediate/int_accounts.sql
+++ b/models/intermediate/int_accounts.sql
@@ -1,0 +1,38 @@
+{{ config(materialized='view') }}
+
+-- Intermediate model: one row per Method account (account grain), keyed on
+-- account_record_id. Current-state account attributes for operational lookup
+-- (call prep, account views): SaaS run-rate, licenses, health, pay type.
+--
+-- Grain: account (RecordID). Distinct from int_customers, which is
+-- entity/customer grain (EntityRecordID) and a monthly time series. Different
+-- key, different purpose -> separate model, not an extension of int_customers.
+--
+-- Source: revenue.Account (Alocet nightly mirror, one row per account —
+-- 146,398 rows, RecordID unique, verified). entity_record_id is retained as
+-- the bridge to entity-grain models (int_customers, int_customer_mrr) which
+-- key on EntityRecordID.
+--
+-- Caveats baked into column choices (see _int_accounts.yml for detail):
+--   * mrr_run_rate = Account.Custdatlastsaasamount, a nightly snapshot
+--     run-rate proxy (excludes prepay discount, portals, overages). NOT
+--     recognized revenue — do not use for board MRR. Directional only.
+--   * user_licenses can be negative in source (credits/adjustments); any
+--     utilization ratio must guard with NULLIF(GREATEST(user_licenses,0),0).
+--   * health_score is ~61% null (populated mainly on active accounts).
+--
+-- PENDING: utilization (active_users_30d / user_licenses) is not built yet.
+-- The numerator (Alocet CustDatCountUsersActiveLast30days) is not in the
+-- revenue.Account mirror. Once that column is added to the nightly load, add
+-- active_users_30d here and the ratio becomes a one-line derivation.
+
+SELECT
+  RecordID              AS account_record_id,
+  CompanyAccount        AS company_account,
+  EntityRecordID        AS entity_record_id,
+  IsActive              AS is_active,
+  SaaSPayType           AS saas_pay_type,
+  Custdatlastsaasamount AS mrr_run_rate,
+  LicenseCount          AS user_licenses,
+  HealthScore           AS health_score
+FROM {{ source('revenue', 'Account') }}


### PR DESCRIPTION
New dbt model `revenue.int_accounts`, one row per account (key = `account_record_id`), sourced from `revenue.Account`. Bridges account grain to the entity-grain revenue models via `entity_record_id`. Backs MRR/licenses on the Call Prep brief.

Columns: mrr_run_rate (run-rate proxy, labeled — not board MRR), user_licenses, health_score, is_active, saas_pay_type, entity_record_id, company_account.

Verified: dbt build + unique/not_null tests pass; MRR/licenses parity-exact vs Alocet for Wave Distro / Montana Mixers / Cladform.

Follow-up: utilization pending `active_users_30d` (CustDatCountUsersActiveLast30days) being added to the revenue.Account nightly load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)