### PR TITLE
feat(call-prep): Revenue & licenses on the brief (int_accounts)

### DIFF
--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -11,6 +11,7 @@ import { queryBqWithRetry } from './bigquery.js';
 export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
 export const TIME_TRACKING_TABLE = '`project-for-method-dw.revenue.TimeTracking`';
 export const CASES_TABLE = '`project-for-method-dw.revenue.Cases`';
+export const ACCOUNTS_TABLE = '`project-for-method-dw.revenue.int_accounts`';
 
 export function buildConsultantsSql() {
   return `
@@ -69,6 +70,23 @@ export function buildAccountSessionsSql(recordId) {
     WHERE MethodCompanyAccountRecordID = ${id}
       AND IsDeleted = FALSE
     ORDER BY TxnDate`;
+}
+
+// Account overview (MRR run-rate, licenses, health) from the dbt model
+// revenue.int_accounts, keyed on account_record_id (= snapshots.account_record_id).
+export function buildAccountOverviewSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT
+      account_record_id,
+      mrr_run_rate,
+      user_licenses,
+      health_score,
+      is_active,
+      saas_pay_type
+    FROM ${ACCOUNTS_TABLE}
+    WHERE account_record_id = ${id}
+    LIMIT 1`;
 }
 
 // Case history from revenue.Cases, keyed on MethodCompanyAccountRecordID.
@@ -145,6 +163,20 @@ export function normalizeSessionRow(row) {
   };
 }
 
+/** Convert a raw int_accounts row into a typed account overview. */
+export function normalizeAccountOverview(row) {
+  if (!row) return null;
+  const licenses = toInt(row.user_licenses);
+  return {
+    accountRecordId: toInt(row.account_record_id),
+    mrrRunRate: toFloat(row.mrr_run_rate),
+    userLicenses: licenses != null && licenses > 0 ? licenses : null,
+    healthScore: toFloat(row.health_score),
+    isActive: toBool(row.is_active),
+    saasPayType: toStr(row.saas_pay_type),
+  };
+}
+
 /** Convert a raw Cases row into a typed camelCase case. */
 export function normalizeCaseRow(row) {
   const status = toStr(row.CaseStatus);
@@ -207,4 +239,9 @@ export async function fetchAccountSessions(recordId, { query = queryBqWithRetry 
 export async function fetchAccountCases(recordId, { query = queryBqWithRetry } = {}) {
   const { rows } = await query(buildAccountCasesSql(recordId));
   return rows.map(normalizeCaseRow);
+}
+
+export async function fetchAccountOverview(recordId, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildAccountOverviewSql(recordId));
+  return normalizeAccountOverview(rows[0]);
 }

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -5,7 +5,7 @@
 // revenue.TimeTracking. All content is sourced from BigQuery — no doc read.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases, computeFlags } from '../lib/callPrep';
+import { fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases, fetchAccountOverview, computeFlags } from '../lib/callPrep';
 
 const PAPER = '#faf8f3';
 const INK = '#1c1a15';
@@ -176,23 +176,28 @@ export default function CallPrepAccount() {
   const [openEvent, setOpenEvent] = useState(null);
   const [cases, setCases] = useState(null);
   const [casesErr, setCasesErr] = useState('');
+  const [overview, setOverview] = useState(null);
   const sheetRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     setHistory(null); setSelectedDate(null); setError('');
     setSessions(null); setSessionsErr(''); setOpenEvent(null);
-    setCases(null); setCasesErr('');
+    setCases(null); setCasesErr(''); setOverview(null);
     fetchAccountSnapshots(recordId)
       .then((h) => { if (!cancelled) setHistory(h); })
       .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
-    // Timeline and cases load independently — a CRM-table failure must not blank the brief.
+    // Timeline, cases, and overview load independently — a CRM/warehouse-table
+    // failure must not blank the brief.
     fetchAccountSessions(recordId)
       .then((rows) => { if (!cancelled) setSessions(rows); })
       .catch((e) => { if (!cancelled) setSessionsErr(e?.message || String(e)); });
     fetchAccountCases(recordId)
       .then((rows) => { if (!cancelled) setCases(rows); })
       .catch((e) => { if (!cancelled) setCasesErr(e?.message || String(e)); });
+    fetchAccountOverview(recordId)
+      .then((o) => { if (!cancelled) setOverview(o); })
+      .catch(() => { if (!cancelled) setOverview(null); });
     return () => { cancelled = true; };
   }, [recordId]);
 
@@ -275,6 +280,7 @@ export default function CallPrepAccount() {
 
         <nav style={s.nav}>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('situation')}>Situation</a>
+          {overview ? <a className="cp-chip" style={s.navChip} onClick={() => jump('revenue')}>Revenue</a> : null}
           <a className="cp-chip" style={s.navChip} onClick={() => jump('timeline')}>Timeline</a>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('cases')}>Cases</a>
           <a className="cp-chip" style={s.navChip} onClick={() => jump('details')}>Details</a>
@@ -295,6 +301,21 @@ export default function CallPrepAccount() {
             <p style={s.empty}>No prep notes recorded for this snapshot.</p>
           )}
         </section>
+
+        {overview && (
+          <section id="revenue" style={s.section}>
+            <div style={s.bodyLabel}>Revenue &amp; licenses</div>
+            <div style={s.grid}>
+              <Detail label="MRR (run-rate)" value={overview.mrrRunRate != null ? `$${overview.mrrRunRate.toLocaleString()}/mo` : null} />
+              <Detail label="User licenses" value={overview.userLicenses} />
+              <Detail label="Health score" value={overview.healthScore != null ? Math.round(overview.healthScore) : null} warn={overview.healthScore != null && overview.healthScore < 50} />
+              <Detail label="Billing" value={overview.saasPayType} />
+            </div>
+            <p style={{ fontSize: 11.5, color: FAINT, marginTop: 12, fontStyle: 'italic' }}>
+              Utilization (active users ÷ licenses) pending an upstream field. MRR is a nightly run-rate proxy, not recognized revenue.
+            </p>
+          </section>
+        )}
 
         <section id="timeline" style={s.section}>
           <div style={s.bodyLabel}>History</div>

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -3,13 +3,15 @@ import {
   CALL_PREP_TABLE,
   TIME_TRACKING_TABLE,
   CASES_TABLE,
+  ACCOUNTS_TABLE,
   buildConsultantsSql,
   buildBookSql,
   buildAccountSnapshotsSql,
   buildAccountSessionsSql,
   buildAccountCasesSql,
+  buildAccountOverviewSql,
 } from '../../src/lib/callPrep.js';
-import { normalizeSnapshotRow, normalizeSessionRow, normalizeCaseRow, computeFlags } from '../../src/lib/callPrep.js';
+import { normalizeSnapshotRow, normalizeSessionRow, normalizeCaseRow, normalizeAccountOverview, computeFlags } from '../../src/lib/callPrep.js';
 import { fetchConsultants, fetchBook, fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases } from '../../src/lib/callPrep.js';
 
 describe('buildConsultantsSql', () => {
@@ -88,6 +90,38 @@ describe('buildAccountCasesSql', () => {
   it('rejects non-integer record ids', () => {
     expect(() => buildAccountCasesSql('1 OR 1=1')).toThrow();
     expect(() => buildAccountCasesSql('abc')).toThrow();
+  });
+});
+
+describe('buildAccountOverviewSql', () => {
+  it('queries int_accounts by account, single row', () => {
+    const sql = buildAccountOverviewSql('90430');
+    expect(sql).toContain(ACCOUNTS_TABLE);
+    expect(sql).toContain('account_record_id = 90430');
+    expect(sql).toMatch(/LIMIT 1/);
+  });
+
+  it('rejects non-integer record ids', () => {
+    expect(() => buildAccountOverviewSql('1; DROP TABLE x')).toThrow();
+  });
+});
+
+describe('normalizeAccountOverview', () => {
+  it('casts an int_accounts row', () => {
+    const a = normalizeAccountOverview({
+      account_record_id: '90430', mrr_run_rate: '209', user_licenses: '5',
+      health_score: '38', is_active: 'true', saas_pay_type: 'Prepay',
+    });
+    expect(a).toEqual({
+      accountRecordId: 90430, mrrRunRate: 209, userLicenses: 5,
+      healthScore: 38, isActive: true, saasPayType: 'Prepay',
+    });
+  });
+
+  it('nulls non-positive license counts (source has negatives) and tolerates a missing row', () => {
+    expect(normalizeAccountOverview({ account_record_id: '1', user_licenses: '-2' }).userLicenses).toBe(null);
+    expect(normalizeAccountOverview({ account_record_id: '1', user_licenses: '0' }).userLicenses).toBe(null);
+    expect(normalizeAccountOverview(undefined)).toBe(null);
   });
 });
 


### PR DESCRIPTION
Renders MRR run-rate, licenses, health, and billing on the account brief from the new `revenue.int_accounts` dbt model. Utilization pending an upstream active-users column. 26 unit tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)