### PR TITLE
feat(call-prep): calendar week strip, searchable book views, and a scoped UI auditor

### DIFF
--- a/.claude/skills/call-prep-ui-audit/SKILL.md
+++ b/.claude/skills/call-prep-ui-audit/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: call-prep-ui-audit
+description: Audit the call-prep screens for AI-slop copy, readability and accessibility faults, and missed at-a-glance signals — then record the findings in a durable ledger so re-runs track what was fixed. Use before shipping a change to any /call-prep route, or to sweep the area.
+---
+
+# Call Prep — UI audit
+
+Sweeps the `/call-prep` routes, scores them against three lenses, and writes the
+result to **`docs/ui-audit-call-prep.md`**, which is a ledger, not a report: each
+finding keeps a stable id across runs so a later sweep can mark it fixed instead
+of renumbering everything.
+
+## Scope
+
+| Route | File |
+|---|---|
+| `#/call-prep` | `builder/src/pages/CallPrep.jsx` |
+| `#/call-prep/:consultant` | `builder/src/pages/CallPrepBook.jsx` |
+| — (week strip) | `builder/src/components/callprep/WeekStrip.jsx` |
+| `#/call-prep/account/:recordId` | `builder/src/pages/CallPrepAccount.jsx` |
+| nav entry | `builder/src/components/Sidebar.jsx` (PS section only) |
+
+Data layers (`lib/callPrep.js`, `lib/googleCalendar.js`) are in scope only for
+strings that reach the screen — error messages, labels, empty-state text.
+
+## Method
+
+1. **Load the `ui-review` skill first.** It holds the AI-slop tells, the microcopy
+   length limits, and the measured contrast table for this codebase's tokens.
+   Follow it rather than substituting taste.
+2. Read every file in scope in full. Copy faults hide in the middle of long style
+   objects.
+3. Score against the three lenses below.
+4. Merge into the ledger. Never renumber an existing finding.
+
+## Lens 1 — AI slop
+
+Per `ui-review`. The archetype in this repo is *statement, em dash, unrequested
+reasoning*. Also: explaining the data model to a consultant, defensive hedging,
+"X, not Y" constructions, and mechanical parallelism across sibling strings.
+
+Call-prep-specific tell: **narrating the matcher**. The calendar guesses which
+account an event belongs to. Explaining *how* it guessed is teaching the
+mechanism; signalling *that it is a guess* is useful. Keep the second, cut the
+first.
+
+## Lens 2 — Readability and access
+
+Per `ui-review`'s checklists, plus the faults this area is prone to:
+
+- **A grid of days is not a list of days.** Columns built from `<div>`s give a
+  screen-reader user no structure. Each day needs a name in the accessibility
+  tree, not just on screen.
+- **`—` is not an empty state.** It renders as "em dash" aloud and as noise
+  visually. Say what is absent.
+- **Filtering without announcement.** Every search box and tab on these screens
+  changes a row count silently. Row counts need a polite live region.
+- **Whose calendar / whose book.** Copy that says "your" is wrong the moment a
+  rep opens a teammate's book. Check every possessive against both cases.
+- **Raw warehouse values.** `sync_status` arrives lowercase from BigQuery. Ship
+  what a person would write, not what the column holds.
+
+## Lens 3 — At a glance
+
+The one that matters most, and the one a generic audit misses. These screens are
+read in the ninety seconds before a call. A finding here asks: **does the screen
+answer the question the rep actually has, without a click?**
+
+The standing questions, in priority order:
+
+1. **Which of today's calls has no prep written?** A call with no brief is the
+   single most actionable thing on the screen. If it looks identical to a
+   prepped call, the screen has failed.
+2. **Which accounts need attention, and how many?** Flags exist per row, but a
+   count belongs above the fold.
+3. **Is this account in trouble *right now*?** Sync failing or open cases should
+   be visible next to the call, not one click into the brief.
+4. **What am I walking into next?** Time, account, and a way in — in that order.
+
+Score every proposed addition against density: this screen is skimmed, so a new
+signal has to displace an existing one or earn its line. Reject anything that is
+merely interesting.
+
+## Output — the ledger
+
+Write or update `docs/ui-audit-call-prep.md`:
+
+- A **status table** at the top: id, one-line summary, status
+  (`open` / `fixed` / `wont-fix`), and the run that changed it.
+- Findings grouped by lens, each with: stable id, `file:line`, the current string
+  **quoted verbatim**, the fault named, and **the exact replacement**. A finding
+  with no replacement is an opinion — drop it.
+- **What's already good**, 2–4 bullets, so the reader can calibrate.
+- Do not pad to a quota. A short honest sweep beats a long one.
+
+Severity: `critical` (misleads, or locks out keyboard/screen-reader users),
+`major` (materially hurts a rep mid-call), `minor` (polish).

--- a/builder/src/components/Sidebar.jsx
+++ b/builder/src/components/Sidebar.jsx
@@ -10,6 +10,13 @@ const NAV_ITEMS = [
   { path: '/', label: 'Home', icon: '\u2302', exact: true },
 ];
 
+// Professional services screens. `/call-prep` bounces straight to the
+// remembered consultant's book, so the link lands on the day view for
+// returning users and on the picker for everyone else.
+const PS_ITEMS = [
+  { path: '/call-prep', label: 'Call Prep', icon: '☎' },
+];
+
 const ADMIN_ITEMS = [
   { path: '/admin/insights', label: 'AI Insights', icon: '\u25C8' },
 ];
@@ -137,6 +144,16 @@ export default function Sidebar({ collapsed, onToggle }) {
             <span style={{ fontSize: 16 }}>{'\u2728'}</span>
             Chart Builder
           </NavLink>
+
+          {/* PS */}
+          <div style={{ height: 1, background: '#e2e5e9', margin: '12px 16px' }} />
+          <div style={sectionLabel}>PS</div>
+          {PS_ITEMS.map(item => (
+            <NavLink key={item.path} to={item.path} end={item.exact} style={linkStyle}>
+              <span style={{ fontSize: 16 }}>{item.icon}</span>
+              {item.label}
+            </NavLink>
+          ))}
 
           {/* My Dashboards (starred AI dashboards only) */}
           {stars.length > 0 && (() => {

--- a/builder/src/components/callprep/WeekStrip.jsx
+++ b/builder/src/components/callprep/WeekStrip.jsx
@@ -1,0 +1,319 @@
+// The week strip at the top of /call-prep/:consultant — the signed-in rep's own
+// Google Calendar, one column per day, read-only.
+//
+// The whole day is shown, not just the calls: an account-matched event gets the
+// account name and a Prep button, everything else still renders so the strip
+// reads as your actual day. "Account calls only" filters down to the matched
+// ones. Matching is the title/attendee heuristic in lib/googleCalendar.js, so
+// showing everything by default also means a mis-match never hides a meeting.
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { connectCalendar } from '../../lib/bigquery';
+import { computeFlags } from '../../lib/callPrep';
+import {
+  CalendarAccessError,
+  CalendarScopeError,
+  addDays,
+  fetchCalendarEvents,
+  fetchCalendarList,
+  formatEventTime,
+  localIsoDate,
+  matchCalendarForConsultant,
+  matchEvents,
+  startOfWeek,
+  weekDays,
+} from '../../lib/googleCalendar';
+
+// Mon–Fri always get a column. Saturday and Sunday only earn one when something
+// is actually scheduled, so a normal week doesn't waste 28% of the width.
+const WEEKDAY_COLUMNS = 5;
+const FULL_WEEK = 7;
+
+const s = {
+  panel: { border: '1px solid #e2e5e9', borderRadius: 8, background: '#fff', padding: 16, marginBottom: 28 },
+  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14, gap: 12 },
+  range: { fontSize: 13, fontWeight: 600, color: '#1a1a1a' },
+  nav: { display: 'flex', gap: 6 },
+  navBtn: {
+    padding: '4px 10px', fontSize: 12, fontFamily: "'DM Sans', sans-serif",
+    color: '#374151', background: '#fff', border: '1px solid #e2e5e9',
+    borderRadius: 6, cursor: 'pointer',
+  },
+  navBtnOn: { color: '#fff', background: '#047857', borderColor: '#047857', fontWeight: 600 },
+
+  grid: { display: 'grid', gap: 8 },
+  col: { minWidth: 0 },
+  colHead: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 700,
+    letterSpacing: '.12em', textTransform: 'uppercase', color: '#6b7280',
+    paddingBottom: 6, borderBottom: '1px solid #e2e5e9', marginBottom: 8,
+  },
+  colHeadToday: { color: '#047857' },
+
+  event: { border: '1px solid #e2e5e9', borderRadius: 6, padding: '8px 10px', marginBottom: 6, background: '#fff' },
+  eventUnmatched: { background: '#f8f9fa' },
+  time: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: '#6b7280', marginBottom: 2 },
+  eventTitle: { fontSize: 13, color: '#1a1a1a', lineHeight: 1.3, overflowWrap: 'anywhere' },
+  account: { fontSize: 12, color: '#6b7280', marginTop: 2, overflowWrap: 'anywhere' },
+  declined: { fontSize: 11, color: '#6b7280', fontStyle: 'italic' },
+  prep: {
+    display: 'inline-block', marginTop: 6, padding: '3px 10px', fontSize: 12,
+    fontWeight: 600, color: '#fff', background: '#047857', borderRadius: 4,
+    textDecoration: 'none',
+  },
+  // A call with no brief written for that day. Muted rather than green so the
+  // eye lands on the prepped calls first, and paired with the chip below —
+  // never colour alone.
+  prepMissing: {
+    display: 'inline-block', marginTop: 6, padding: '3px 10px', fontSize: 12,
+    fontWeight: 600, color: '#374151', background: '#fff',
+    border: '1px solid #e2e5e9', borderRadius: 4, textDecoration: 'none',
+  },
+  chipRow: { display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 6 },
+  chipWarn: {
+    fontSize: 10.5, fontWeight: 600, color: '#b45309', background: '#fffbeb',
+    border: '1px solid #fde68a', borderRadius: 3, padding: '1px 6px',
+  },
+  chipMuted: {
+    fontSize: 10.5, fontWeight: 600, color: '#6b7280', background: '#f8f9fa',
+    border: '1px solid #e2e5e9', borderRadius: 3, padding: '1px 6px',
+  },
+  guess: { fontSize: 11, color: '#6b7280', marginTop: 4 },
+  empty: { fontSize: 12, color: '#6b7280', padding: '6px 0' },
+
+  footer: { marginTop: 12, fontSize: 12, color: '#6b7280' },
+
+  connect: { textAlign: 'center', padding: '20px 0' },
+  connectText: { fontSize: 14, color: '#6b7280', marginBottom: 12 },
+  connectBtn: {
+    padding: '8px 18px', fontSize: 14, fontWeight: 600, color: '#fff',
+    background: '#047857', border: 'none', borderRadius: 6, cursor: 'pointer',
+    fontFamily: "'DM Sans', sans-serif",
+  },
+  note: { fontSize: 13, color: '#6b7280', padding: '8px 0' },
+  error: { fontSize: 13, color: '#b91c1c', padding: '8px 0' },
+};
+
+const monthDay = (iso) =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString([], { month: 'short', day: 'numeric' });
+const dayName = (iso) =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString([], { weekday: 'short' });
+/** "Monday, August 10" — the accessible name for a day column. */
+const fullDay = (iso) =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString([], { weekday: 'long', month: 'long', day: 'numeric' });
+
+const MAX_CHIPS = 2;
+
+export default function WeekStrip({ accounts, consultant, ownBook, preps }) {
+  const [weekStart, setWeekStart] = useState(() => startOfWeek());
+  const [events, setEvents] = useState(null);
+  const [error, setError] = useState(null);
+  const [callsOnly, setCallsOnly] = useState(false);
+  // null = still resolving, false = no subscribed calendar for this consultant.
+  const [calendar, setCalendar] = useState(ownBook ? { id: 'primary', primary: true } : null);
+  const [resolved, setResolved] = useState(ownBook);
+
+  // Someone else's book: only their calendar counts, and only if this user is
+  // already subscribed to it. We never guess an address.
+  useEffect(() => {
+    if (ownBook) {
+      setCalendar({ id: 'primary', primary: true });
+      setResolved(true);
+      return undefined;
+    }
+    let cancelled = false;
+    setResolved(false);
+    setCalendar(null);
+    fetchCalendarList()
+      .then((list) => {
+        if (cancelled) return;
+        setCalendar(matchCalendarForConsultant(consultant, list));
+        setResolved(true);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e);
+        setResolved(true);
+      });
+    return () => { cancelled = true; };
+  }, [consultant, ownBook]);
+
+  // Always fetch the whole week; which columns get rendered is decided below,
+  // after we know where the events actually landed.
+  const allDays = weekDays(weekStart, FULL_WEEK);
+  const from = allDays[0];
+  const to = allDays[allDays.length - 1];
+
+  const load = useCallback(() => {
+    if (!calendar) return undefined;
+    let cancelled = false;
+    setEvents(null);
+    setError(null);
+    fetchCalendarEvents(from, to, { calendarId: calendar.id })
+      .then((list) => { if (!cancelled) setEvents(list); })
+      .catch((e) => { if (!cancelled) setError(e); });
+    return () => { cancelled = true; };
+  }, [from, to, calendar]);
+
+  useEffect(() => load(), [load]);
+
+  const connect = () => connectCalendar(() => load());
+
+  // "Was a brief written for this account on this day?" — the prep history is
+  // already loaded by the page, so answering it costs a Set rather than a query.
+  const prepDays = useMemo(
+    () => new Set((preps ?? []).map((p) => `${p.accountRecordId}|${p.snapshotDate}`)),
+    [preps]
+  );
+  // Latest-snapshot flags per account, so a failing sync is visible on the
+  // calendar card instead of one click into the brief.
+  const flagsByAccount = useMemo(() => {
+    const today = localIsoDate();
+    return new Map((accounts ?? []).map((a) => [a.accountRecordId, computeFlags(a, today)]));
+  }, [accounts]);
+
+  if (error instanceof CalendarScopeError) {
+    return (
+      <div style={s.panel}>
+        <div style={s.connect}>
+          <p style={s.connectText}>Connect your Google Calendar to see this week’s calls.</p>
+          <button type="button" style={s.connectBtn} onClick={connect}>Connect calendar</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!resolved) {
+    return <div style={s.panel}><div style={s.note}>Looking for {consultant}’s calendar…</div></div>;
+  }
+  if (!calendar) {
+    return (
+      <div style={s.panel}>
+        <div style={s.note}>
+          You’re not subscribed to {consultant}’s calendar. Add it in Google Calendar to see their week here.
+        </div>
+      </div>
+    );
+  }
+
+  const matched = events ? matchEvents(events, accounts) : [];
+  const callCount = matched.filter((e) => e.match).length;
+  const visible = callsOnly ? matched.filter((e) => e.match) : matched;
+  const todayIso = localIsoDate();
+
+  // Weekend columns are driven by the full event set, not the filtered one, so
+  // toggling "Account calls only" can't make a column appear and disappear.
+  const days = allDays.filter(
+    (iso, i) => i < WEEKDAY_COLUMNS || matched.some((e) => e.day === iso)
+  );
+
+  return (
+    <div style={s.panel}>
+      <div style={s.head}>
+        <span style={s.range}>
+          {monthDay(days[0])} – {monthDay(days[days.length - 1])}
+          {!calendar.primary && calendar.summary ? ` · ${calendar.summary}` : ''}
+        </span>
+        <div style={s.nav}>
+          <button
+            type="button"
+            aria-pressed={callsOnly}
+            style={{ ...s.navBtn, ...(callsOnly ? s.navBtnOn : null) }}
+            onClick={() => setCallsOnly((v) => !v)}
+          >
+            Account calls only
+          </button>
+          <button type="button" style={s.navBtn} onClick={() => setWeekStart(addDays(weekStart, -7))}>
+            Previous
+          </button>
+          <button type="button" style={s.navBtn} onClick={() => setWeekStart(startOfWeek())}>
+            This week
+          </button>
+          <button type="button" style={s.navBtn} onClick={() => setWeekStart(addDays(weekStart, 7))}>
+            Next
+          </button>
+        </div>
+      </div>
+
+      {error instanceof CalendarAccessError
+        ? <div style={s.error}>You don’t have read access to {consultant}’s calendar.</div>
+        : error && <div style={s.error}>Couldn’t load the calendar: {error.message}</div>}
+      {!events && !error && <div style={s.note}>Loading the calendar…</div>}
+
+      {events && !matched.length && (
+        <div style={s.note}>Nothing on the calendar this week.</div>
+      )}
+
+      {events && matched.length > 0 && (
+        <>
+          <div style={{ ...s.grid, gridTemplateColumns: `repeat(${days.length}, 1fr)` }}>
+            {days.map((iso) => {
+              const dayEvents = visible.filter((e) => e.day === iso);
+              const isToday = iso === todayIso;
+              return (
+                // role="group" rather than a heading: it puts the day's name in
+                // the accessibility tree without inventing a heading level that
+                // would break the page's hierarchy.
+                <div key={iso} style={s.col} role="group" aria-label={fullDay(iso)}>
+                  <div style={{ ...s.colHead, ...(isToday ? s.colHeadToday : null) }}>
+                    {dayName(iso)} {monthDay(iso)}{isToday ? ' · today' : ''}
+                  </div>
+                  {!dayEvents.length && <div style={s.empty}>No events</div>}
+                  {dayEvents.map((event) => {
+                    const account = event.match?.account;
+                    // A prep is only "missing" for a call that hasn't happened.
+                    // On a past day it's history, not something to act on.
+                    const prepped = account
+                      && prepDays.has(`${account.accountRecordId}|${event.day}`);
+                    const missingPrep = Boolean(account) && !prepped && event.day >= todayIso;
+                    const flags = account ? (flagsByAccount.get(account.accountRecordId) ?? []) : [];
+                    const overflow = flags.length - MAX_CHIPS;
+                    return (
+                      <div
+                        key={event.id}
+                        style={{ ...s.event, ...(event.match ? null : s.eventUnmatched) }}
+                      >
+                        <div style={s.time}>{formatEventTime(event)}</div>
+                        <div style={s.eventTitle}>{event.title}</div>
+                        {event.declined && <div style={s.declined}>You declined</div>}
+                        {account && (
+                          <>
+                            <div style={s.account}>{account.accountName}</div>
+                            {flags.length > 0 && (
+                              <div style={s.chipRow}>
+                                {flags.slice(0, MAX_CHIPS).map((f) => (
+                                  <span key={f} style={s.chipWarn}>{f}</span>
+                                ))}
+                                {overflow > 0 && <span style={s.chipMuted}>+{overflow}</span>}
+                              </div>
+                            )}
+                            <Link
+                              style={missingPrep ? s.prepMissing : s.prep}
+                              to={`/call-prep/account/${encodeURIComponent(account.accountRecordId)}`}
+                            >
+                              {missingPrep ? 'Open' : 'Prep'}
+                            </Link>
+                            {missingPrep && <div style={s.chipRow}><span style={s.chipWarn}>no prep</span></div>}
+                            {event.match.via === 'attendee' && (
+                              <div style={s.guess}>Best guess</div>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+
+          <div style={s.footer}>
+            {callsOnly
+              ? `${visible.length} of ${matched.length} events · linked to an account`
+              : `${matched.length} events · ${callCount} linked to an account`}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/builder/src/dev/fixtures/customer.js
+++ b/builder/src/dev/fixtures/customer.js
@@ -189,6 +189,8 @@ function brief(o) {
     business_context: str(o.businessContext),
     contact_name: str(o.contactName),
     contact_email: str(o.contactEmail),
+    contact_phone: str(o.contactPhone ?? null),
+    website: str(o.website ?? null),
   };
 }
 
@@ -365,6 +367,9 @@ function build() {
       businessContext: 'Wholesale distributor, 24 users, second location planned for the fall.',
       contactName: 'Dana Whitcombe',
       contactEmail: 'dana@northwind.example',
+      contactPhone: '(555) 0142-887',
+      // Scheme-less, like every real brief_content row — exercises toWebsiteUrl.
+      website: 'northwind.example',
     }),
     brief({
       accountId: 900104, date: iso(0), time: '11:30:00',
@@ -377,6 +382,8 @@ function build() {
       businessContext: 'Building-materials supplier, 47 users, three branches.',
       contactName: 'Marcus Reyes',
       contactEmail: 'marcus@pikepowell.example',
+      contactPhone: '(555) 0198-204',
+      website: 'https://pikepowell.example',
     }),
   ];
 

--- a/builder/src/dev/fixtures/ps.js
+++ b/builder/src/dev/fixtures/ps.js
@@ -49,6 +49,8 @@ function snapshot(o) {
     signup_date: iso(-Math.round(ageMonths * 30.4)),
     dep_enrolled: bool(o.dep),
     multi_entity_parent_name: str(o.parent ?? null),
+    multi_entity_parent_record_id: o.parent ? str(o.parentId ?? 900199) : null,
+    parent_is_dep: o.parent ? bool(o.parentIsDep) : null,
     sync_fail_count: str(o.syncFails ?? 0),
     sync_status: o.syncStatus ?? (o.syncFails ? 'FAILING' : 'OK'),
     tt_total_hours: str(o.hours ?? 12.5),
@@ -128,7 +130,7 @@ function accountSeed() {
       id: 900105, name: 'Bright Harbor Logistics', consultant: ME_FULL, callType: 'PPU',
       ageMonths: 15, syncFails: 0, casesOpen: 0, casesClosed: 3, hours: 19,
       sessions: 11, lastSession: iso(-9), dep: false,
-      parent: 'Bright Harbor Holdings',
+      parent: 'Bright Harbor Holdings', parentId: 900190, parentIsDep: true,
       industry: ['Transportation', 'Freight Brokerage', '3PL'],
       operatingModel: 'Dispatch', confidence: 0.68,
       mrr: 1120, licenses: 16, health: 84, active: true, payType: 'Monthly',
@@ -204,6 +206,49 @@ const CASE_SUBJECTS = [
   'Portal login link expired',
 ];
 const CONTACTS = ['Dana Whitcombe', 'Marcus Reyes', 'Priya Nandakumar', 'Ellis Vaughn', 'Tomas Berg'];
+
+// revenue.Activity — Comments arrive as CRM rich text, so these carry real tags
+// and entities to exercise stripHtml() rather than reading as clean prose.
+const ACTIVITY_TYPES = [
+  'Demo', 'AI Summary - Demo', 'Chat Incoming', 'Phone Call Outgoing',
+  'Email Incoming & Outgoing', 'Phone Call Incoming', 'Chat Incoming',
+];
+const ACTIVITY_COMMENTS = [
+  '<p>Walked the estimate flow end to end. Customer wants package pricing with terms text instead of itemised lines.</p>',
+  '<p><strong>Meeting Summary</strong></p><p>Reviewed onboarding progress; QuickBooks sync confirmed clean &amp; no open blockers.</p>',
+  'Question<br>The customer asked how to create jobs from an approved estimate.',
+  '<p>Called to check in on setup &nbsp;&mdash; left voicemail.</p>',
+  '<div>Sent the getting-started guide and booked the follow-up session.</div>',
+  '<p>Customer could not log in; reset the password and confirmed access.</p>',
+];
+
+// call_prep.opportunity_fit — one row per motion, matching the four the routine
+// always assesses. Northwind is the interesting case: two flagged motions with
+// signals and a caveat.
+const FIT_SEEDS = {
+  900101: [
+    { motion: 'method_pay', fit: 'strong', hook: 'overdue_invoice_reminders',
+      signals: ['AR chased manually in TT notes', 'No gateway connected'],
+      rationale: 'Two sessions mention chasing overdue invoices by hand, and no payment gateway is connected.',
+      caveats: 'Method Pay hook naming is not confirmed with Product — do not present as a named feature.' },
+    { motion: 'dep', fit: 'moderate',
+      signals: ['22 sessions over 26 months', 'Recurring sync topic across consultants'],
+      rationale: '41 billed hours across 22 sessions, with the same QuickBooks sync topic re-explained to three consultants.' },
+    { motion: 'ppu', fit: 'current', signals: ['current_ppu_booking'],
+      rationale: 'Today’s booking is a PPU session.' },
+    { motion: 'free_hour', fit: 'none', signals: [],
+      rationale: 'Free Hour was used in the first month; the account is on paid consulting now.' },
+  ],
+  900103: [
+    { motion: 'method_pay', fit: 'none', signals: [], rationale: 'No payment friction anywhere in account history.' },
+    { motion: 'dep', fit: 'none', signals: [],
+      rationale: 'Account is ~3 months old with 2 sessions — no volume, complexity or continuity signal.' },
+    { motion: 'ppu', fit: 'moderate', signals: ['Second free session requested'],
+      rationale: 'A second scoping request arrived after the free hour was used.' },
+    { motion: 'free_hour', fit: 'current', signals: ['current_free_hour_booking'],
+      rationale: 'Today’s booking is the account’s complimentary Free Hour.' },
+  ],
+};
 
 function build() {
   const seeds = accountSeed();
@@ -283,6 +328,39 @@ function build() {
     ];
   });
 
+  // revenue.Activity — the brief's "Recent activities". Every account gets a
+  // run so the section is never empty, newest first.
+  const ACTIVITIES = seeds.flatMap((seed) =>
+    Array.from({ length: 7 }, (_, i) => ({
+      _account: str(seed.id),
+      RecordID: str(seed.id * 100 + i),
+      occurred_on: iso(-(i * 4 + 1)),
+      ActivityType: ACTIVITY_TYPES[(seed.id + i) % ACTIVITY_TYPES.length],
+      ActivityStatus: 'Completed',
+      AssignedToRecordID: str(455 + ((seed.id + i) % 3)),
+      Comments: ACTIVITY_COMMENTS[(seed.id + i) % ACTIVITY_COMMENTS.length],
+    }))
+  );
+
+  // call_prep.opportunity_fit — only two accounts are seeded, so the page's
+  // "no assessment yet" branch stays reachable.
+  const OPPORTUNITY_FIT = Object.entries(FIT_SEEDS).flatMap(([id, rows]) =>
+    rows.map((r) => ({
+      _account: str(id),
+      account_record_id: str(id),
+      account_name: seeds.find((s) => String(s.id) === id)?.name ?? null,
+      motion: r.motion,
+      fit: r.fit,
+      rationale: r.rationale,
+      signals: repeated(r.signals),
+      recommended_hook: r.hook ?? null,
+      caveats: r.caveats ?? null,
+      assessed_date: iso(0),
+      review_status: 'new',
+      first_flagged_date: iso(0),
+    }))
+  );
+
   // call_prep.handoffs — empty in real BQ today (see docs/ps-hub.md), so these
   // fixtures are the only way to see the Handoffs screens with content. One row
   // per status change, newest first per account.
@@ -324,7 +402,7 @@ function build() {
     }),
   ];
 
-  return { SNAPSHOTS, ACCOUNTS, SESSIONS, CASES, HANDOFFS };
+  return { SNAPSHOTS, ACCOUNTS, SESSIONS, CASES, HANDOFFS, ACTIVITIES, OPPORTUNITY_FIT };
 }
 
 let cache = null;

--- a/builder/src/dev/mockBq.js
+++ b/builder/src/dev/mockBq.js
@@ -44,6 +44,8 @@ const T = {
   freeHourAudit: 'call_audits.free_hour_audit',
   briefContent: 'call_prep.brief_content',
   account: 'revenue.Account',
+  opportunityFit: 'call_prep.opportunity_fit',
+  activity: 'revenue.Activity',
 };
 
 const hits = (sql, table) => sql.includes(table);
@@ -235,6 +237,8 @@ const ROUTES = [
     },
   },
   {
+    // Serves both the customer page's prep list and the call-prep account brief;
+    // the two queries differ only in their column list.
     name: 'call preps + brief content',
     when: (sql) => hits(sql, T.snapshots) && hits(sql, T.briefContent),
     rows: (sql) => {
@@ -254,6 +258,8 @@ const ROUTES = [
             business_context: brief?.business_context ?? null,
             contact_name: brief?.contact_name ?? null,
             contact_email: brief?.contact_email ?? null,
+            contact_phone: brief?.contact_phone ?? null,
+            website: brief?.website ?? null,
           };
         })
         .sort(desc('snapshot_date'));
@@ -567,6 +573,26 @@ const ROUTES = [
       return clean(fixtures().CASES.filter((c) => Number(c._account) === id))
         .map(({ CaseSubject, Subject, ...rest }) => ({ ...rest, subject: CaseSubject ?? Subject }))
         .sort(desc('CreatedDate'));
+    },
+  },
+  {
+    name: 'opportunity fit (per motion)',
+    when: (sql) => hits(sql, T.opportunityFit),
+    rows: (sql) => {
+      const id = intOf(sql, /account_record_id = (\d+)/);
+      return clean(fixtures().OPPORTUNITY_FIT.filter((r) => Number(r._account) === id))
+        .sort((a, b) => desc('assessed_date')(a, b) || a.motion.localeCompare(b.motion));
+    },
+  },
+  {
+    name: 'recent activities',
+    when: (sql) => hits(sql, T.activity),
+    rows: (sql) => {
+      const id = intOf(sql, /MethodCompanyAccountRecordID = (\d+)/);
+      const limit = intOf(sql, /LIMIT (\d+)/) ?? 10;
+      return clean(fixtures().ACTIVITIES.filter((a) => Number(a._account) === id))
+        .sort(desc('occurred_on'))
+        .slice(0, limit);
     },
   },
   {

--- a/builder/src/dev/mockCalendar.js
+++ b/builder/src/dev/mockCalendar.js
@@ -1,0 +1,129 @@
+// Fixture-backed stand-in for the Google Calendar API. Active only in MOCK_MODE.
+//
+// THIS FILE MUST STAY FAKE — same rule as fixtures/ps.js. Every meeting title,
+// attendee and domain below is invented. Never paste a real calendar export here.
+//
+// Rows come back in the raw Google Calendar v3 shape, not the normalized one, so
+// mock runs travel through the same normalizeEvent() path as production.
+//
+// The set deliberately covers all four matching outcomes, so the strip's hidden
+// -events affordance is reachable offline:
+//   - account name in full in the title      → matched via title
+//   - one distinctive word in the title      → matched via title
+//   - nothing in the title, attendee domain  → matched via attendee
+//   - internal meetings and a declined call  → no match, hidden behind the count
+
+const WEEKDAY_MEETINGS = [
+  {
+    hour: 9,
+    minute: 0,
+    summary: 'Northwind Traders — PPU session',
+    attendees: ['dana@northwindtraders.com'],
+  },
+  {
+    hour: 10,
+    minute: 30,
+    summary: 'Harborview check-in',
+    attendees: ['ops@harborviewdental.com'],
+  },
+  {
+    hour: 13,
+    minute: 0,
+    summary: 'Quarterly workflow review',
+    attendees: ['ap@cedarlinemillwork.com'],
+  },
+  {
+    hour: 14,
+    minute: 30,
+    summary: 'PS team standup',
+    attendees: ['ps-team@method.me'],
+  },
+  {
+    hour: 15,
+    minute: 30,
+    summary: 'Tallgrass Landscaping — sync troubleshooting',
+    attendees: ['bill@tallgrasslandscaping.com'],
+    declined: true,
+  },
+];
+
+// One Saturday item, so the strip's "weekend only gets a column when something
+// is on it" rule is reachable offline, and one all-day event.
+const WEEKEND_MEETINGS = [
+  { allDay: true, summary: 'On call — PS rotation', attendees: [] },
+];
+
+/** Every YYYY-MM-DD from `fromIso` to `toIso` inclusive. */
+function daysBetween(fromIso, toIso) {
+  const out = [];
+  const end = new Date(`${toIso}T00:00:00`);
+  for (let d = new Date(`${fromIso}T00:00:00`); d <= end; d.setDate(d.getDate() + 1)) {
+    const pad = (n) => String(n).padStart(2, '0');
+    out.push(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`);
+  }
+  return out;
+}
+
+const isWeekend = (iso) => [0, 6].includes(new Date(`${iso}T00:00:00`).getDay());
+
+function localDateTime(iso, hour, minute) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${iso}T${pad(hour)}:${pad(minute)}:00`;
+}
+
+/**
+ * Meetings across the requested range. Laid out per weekday rather than pinned
+ * to fixed dates so paging to any week still shows something to design against.
+ * The count varies by weekday index to keep the columns visibly uneven.
+ */
+/**
+ * Calendars the mock user is "subscribed" to. Sherry is here so a teammate's
+ * book renders offline; Vinesh deliberately is NOT, so the not-subscribed state
+ * is reachable too (the ps fixtures give both of them accounts).
+ */
+export function mockCalendarList() {
+  return [
+    { id: 'b.saltzman@method.me', summary: 'Brandon Saltzman', primary: true },
+    { id: 's.zarei@method.me', summary: 'Sherry Zarei', primary: false },
+    { id: 'ps-team@method.me', summary: 'PS Team Events', primary: false },
+  ];
+}
+
+export function mockCalendarEvents(fromIso, toIso, calendarId = 'primary') {
+  // A teammate's calendar returns a thinner day, so switching books offline
+  // visibly changes the strip instead of echoing the same fixture back.
+  const perDay = calendarId === 'primary' ? null : 2;
+  const events = [];
+  const push = (iso, i, meeting) => {
+    events.push({
+      id: `mock-${iso}-${i}`,
+      summary: meeting.summary,
+      start: meeting.allDay
+        ? { date: iso }
+        : { dateTime: localDateTime(iso, meeting.hour, meeting.minute) },
+      end: meeting.allDay
+        ? { date: iso }
+        : { dateTime: localDateTime(iso, meeting.hour + 1, meeting.minute) },
+      htmlLink: 'https://calendar.google.com/calendar/u/0/r',
+      attendees: [
+        { email: 'b.saltzman@method.me', self: true, responseStatus: meeting.declined ? 'declined' : 'accepted' },
+        ...meeting.attendees.map((email) => ({ email, responseStatus: 'accepted' })),
+      ],
+    });
+  };
+
+  let weekdayIndex = 0;
+  for (const iso of daysBetween(fromIso, toIso)) {
+    if (isWeekend(iso)) {
+      // Saturday only — Sunday stays clear, so the strip is seen both ways.
+      if (new Date(`${iso}T00:00:00`).getDay() === 6) {
+        WEEKEND_MEETINGS.forEach((meeting, i) => push(iso, i, meeting));
+      }
+      continue;
+    }
+    const count = perDay ?? 2 + (weekdayIndex % 3);
+    WEEKDAY_MEETINGS.slice(0, count).forEach((meeting, i) => push(iso, i, meeting));
+    weekdayIndex += 1;
+  }
+  return events;
+}

--- a/builder/src/lib/bigquery.js
+++ b/builder/src/lib/bigquery.js
@@ -18,6 +18,19 @@ const BQ_CLIENT_ID = '546732685010-nojjfak7esmun2taour8r5pakrsrg3aq.apps.googleu
 const BQ_PROJECT = 'project-for-method-dw';
 const BQ_DATASET = 'revenue';
 
+const BQ_SCOPES = [
+  'https://www.googleapis.com/auth/bigquery',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
+// Read-only calendar, requested on top of the BQ scopes so the call-prep week
+// strip can show clock times.
+//
+// `calendar.readonly` rather than the narrower `calendar.events.readonly`
+// because the strip also lists which calendars you're subscribed to, so a rep's
+// book can show that rep's calendar. calendarList.list is not covered by the
+// events-only scope. Still read-only — nothing here writes to a calendar.
+export const CALENDAR_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly';
+
 let bqToken = localStorage.getItem('bq_access_token');
 
 export function getBqToken() {
@@ -74,11 +87,11 @@ export async function initBqAuth(onSuccess, onFail) {
   }
 }
 
-export function connectBq(onSuccess) {
+function requestToken(scopes, onSuccess) {
   if (!window.google?.accounts?.oauth2) return;
   google.accounts.oauth2.initTokenClient({
     client_id: BQ_CLIENT_ID,
-    scope: 'https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/userinfo.email',
+    scope: scopes.join(' '),
     prompt: '',
     callback: (r) => {
       if (r.access_token) {
@@ -88,6 +101,22 @@ export function connectBq(onSuccess) {
       }
     },
   }).requestAccessToken();
+}
+
+export function connectBq(onSuccess) {
+  requestToken([...BQ_SCOPES, CALENDAR_SCOPE], onSuccess);
+}
+
+/**
+ * Re-request the same token with the calendar scope added.
+ *
+ * Tokens minted before the calendar scope existed still pass the BigQuery
+ * validation in initBqAuth, so those users stay signed in and only discover the
+ * gap when a calendar call 403s. This upgrades that token in place — same
+ * storage key, one combined token — rather than making everyone reconnect.
+ */
+export function connectCalendar(onSuccess) {
+  requestToken([...BQ_SCOPES, CALENDAR_SCOPE], onSuccess);
 }
 
 export function disconnectBq() {

--- a/builder/src/lib/callPrep.js
+++ b/builder/src/lib/callPrep.js
@@ -9,9 +9,12 @@ import { validateInt } from './sanitize.js';
 import { queryBqWithRetry } from './bigquery.js';
 
 export const CALL_PREP_TABLE = '`project-for-method-dw.call_prep.snapshots`';
+export const BRIEF_CONTENT_TABLE = '`project-for-method-dw.call_prep.brief_content`';
 export const TIME_TRACKING_TABLE = '`project-for-method-dw.revenue.TimeTracking`';
 export const CASES_TABLE = '`project-for-method-dw.revenue.Cases`';
 export const ACCOUNTS_TABLE = '`project-for-method-dw.revenue.int_accounts`';
+export const OPPORTUNITY_FIT_TABLE = '`project-for-method-dw.call_prep.opportunity_fit`';
+export const ACTIVITY_TABLE = '`project-for-method-dw.revenue.Activity`';
 
 export function buildConsultantsSql() {
   return `
@@ -43,13 +46,59 @@ export function buildBookSql(consultant) {
     ORDER BY snapshot_date DESC`;
 }
 
-export function buildAccountSnapshotsSql(recordId) {
-  const id = validateInt(recordId, 'account_record_id');
+// Every prep this consultant has, newest first — one row per account per day,
+// not deduped to the latest like buildBookSql. Feeds both the Today and Past
+// preps tabs, which are the same rows split on snapshot_date.
+export const PREP_HISTORY_LIMIT = 500;
+
+export function buildPrepHistorySql(consultant, limit = PREP_HISTORY_LIMIT) {
+  const name = escapeSqlLiteral(consultant);
+  const rows = validateInt(limit, 'limit');
   return `
     SELECT *
     FROM ${CALL_PREP_TABLE}
-    WHERE account_record_id = ${id}
-    ORDER BY snapshot_date DESC`;
+    WHERE consultant = '${name}'
+    ORDER BY snapshot_date DESC, account_name
+    LIMIT ${rows}`;
+}
+
+// The account brief. snapshots carries the account facts; brief_content carries
+// the written parts of the /call-prep doc — the top 3 points, why today, the
+// business summary and the contact. brief_content stopped being written on
+// 2026-07-16 and only ever covered 24 preps, so LEFT JOIN: an older prep still
+// renders, just without the prose.
+//
+// Both tables are append-only and neither has a key, so a routine that runs
+// twice in a day leaves two rows for the same (account, date) — measured
+// 2026-08-10: 7 such pairs in snapshots, 1 in brief_content. Without the two
+// QUALIFYs below that duplicate would fan the join out and show the same date
+// twice in the date picker. Newest row per date wins.
+export function buildAccountSnapshotsSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT
+      s.*,
+      b.scheduled_time,
+      b.top_3,
+      b.why_today,
+      b.business_context,
+      b.contact_name,
+      b.contact_email,
+      b.contact_phone,
+      b.website
+    FROM ${CALL_PREP_TABLE} s
+    LEFT JOIN (
+      SELECT *
+      FROM ${BRIEF_CONTENT_TABLE}
+      QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY account_record_id, snapshot_date ORDER BY created_at DESC
+      ) = 1
+    ) b
+      ON b.account_record_id = s.account_record_id
+     AND b.snapshot_date = s.snapshot_date
+    WHERE s.account_record_id = ${id}
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY s.snapshot_date ORDER BY s.created_at DESC) = 1
+    ORDER BY s.snapshot_date DESC`;
 }
 
 // Session history for the account's timeline. TimeTracking keys to the account
@@ -109,6 +158,61 @@ export function buildAccountCasesSql(recordId) {
     LIMIT 25`;
 }
 
+// Opportunity fit — the brief's per-motion Method Pay / DEP / PPU / Free Hour
+// assessment, written by the team call-prep routine. Append-only, one row per
+// account + motion + assessed_date, so take the newest assessment per motion
+// that is not newer than the prep being read.
+export function buildAccountOpportunityFitSql(recordId) {
+  const id = validateInt(recordId, 'account_record_id');
+  return `
+    SELECT
+      motion,
+      fit,
+      rationale,
+      signals,
+      recommended_hook,
+      caveats,
+      assessed_date,
+      review_status,
+      first_flagged_date
+    FROM ${OPPORTUNITY_FIT_TABLE}
+    WHERE account_record_id = ${id}
+    ORDER BY assessed_date DESC, motion`;
+}
+
+// Recent activities — the brief's "Recent Activities (last 10)". Unlike Alocet's
+// Activity table, the BigQuery copy carries MethodCompanyAccountRecordID, so it
+// joins to an account directly.
+//
+// The date is aliased occurred_on, not activity_date: mockBq's batched
+// cross-account indicator route matches on `AS activity_date` and would
+// otherwise swallow this query.
+//
+// COST: revenue.Activity is ~143 MB and neither partitioned nor clustered, and
+// Comments is nearly all of it. One account's activities therefore scan the
+// whole column (~136 MB measured 2026-08-10) no matter how narrow the WHERE or
+// how small the LIMIT. That is why this fetches once per page load and truncates
+// Comments server-side rather than paging.
+export const ACTIVITY_LIMIT = 10;
+
+export function buildAccountActivitiesSql(recordId, limit = ACTIVITY_LIMIT) {
+  const id = validateInt(recordId, 'account_record_id');
+  const rows = validateInt(limit, 'limit');
+  return `
+    SELECT
+      RecordID,
+      COALESCE(DueDateStart, DATE(CreatedDate)) AS occurred_on,
+      ActivityType,
+      ActivityStatus,
+      AssignedToRecordID,
+      SUBSTR(Comments, 0, 2000) AS Comments
+    FROM ${ACTIVITY_TABLE}
+    WHERE MethodCompanyAccountRecordID = ${id}
+      AND IsDeleted = FALSE
+    ORDER BY occurred_on DESC, RecordID DESC
+    LIMIT ${rows}`;
+}
+
 const toInt = (v, fallback = null) => (v == null || v === '' ? fallback : parseInt(v, 10));
 const toFloat = (v) => (v == null || v === '' ? null : parseFloat(v));
 const toBool = (v) => v === true || v === 'true';
@@ -118,6 +222,19 @@ const toStr = (v) => (v == null || v === '' ? null : String(v));
 const toHttpUrl = (v) => {
   const s = toStr(v);
   return s && /^https?:\/\//i.test(s) ? s : null;
+};
+
+/**
+ * brief_content.website is written scheme-less on every historical row
+ * ("primodoors.com"), which toHttpUrl drops. Accept a bare host and give it
+ * https://, still refusing anything that isn't a plain domain — the value ends
+ * up in an <a href>, where React does not block javascript:/data:.
+ */
+export const toWebsiteUrl = (v) => {
+  const s = toStr(v)?.trim();
+  if (!s) return null;
+  if (/^https?:\/\//i.test(s)) return s;
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(s) ? `https://${s}` : null;
 };
 
 /** Convert a raw BQ REST row (all strings, [{v}] arrays) into typed camelCase. */
@@ -132,6 +249,8 @@ export function normalizeSnapshotRow(row) {
     signupDate: toStr(row.signup_date),
     depEnrolled: toBool(row.dep_enrolled),
     multiEntityParentName: toStr(row.multi_entity_parent_name),
+    multiEntityParentRecordId: toInt(row.multi_entity_parent_record_id),
+    parentIsDep: toBool(row.parent_is_dep),
     syncFailCount: toInt(row.sync_fail_count, 0),
     syncStatus: toStr(row.sync_status)?.toLowerCase() ?? null,
     ttTotalHours: toFloat(row.tt_total_hours),
@@ -147,6 +266,15 @@ export function normalizeSnapshotRow(row) {
     bqConfidence: toFloat(row.bq_confidence),
     docLink: toHttpUrl(row.doc_link),
     createdAt: toStr(row.created_at),
+    // brief_content — null on every prep the doc-writer didn't cover.
+    scheduledTime: toStr(row.scheduled_time),
+    top3: (row.top_3 || []).map((x) => x?.v).filter(Boolean),
+    whyToday: toStr(row.why_today),
+    businessContext: toStr(row.business_context),
+    contactName: toStr(row.contact_name),
+    contactEmail: toStr(row.contact_email),
+    contactPhone: toStr(row.contact_phone),
+    website: toWebsiteUrl(row.website),
   };
 }
 
@@ -174,6 +302,58 @@ export function normalizeAccountOverview(row) {
     healthScore: toFloat(row.health_score),
     isActive: toBool(row.is_active),
     saasPayType: toStr(row.saas_pay_type),
+  };
+}
+
+/** Convert a raw opportunity_fit row into a typed camelCase assessment. */
+export function normalizeOpportunityFitRow(row) {
+  return {
+    motion: toStr(row.motion),
+    fit: toStr(row.fit)?.toLowerCase() ?? null,
+    rationale: toStr(row.rationale),
+    signals: (row.signals || []).map((x) => x?.v).filter(Boolean),
+    recommendedHook: toStr(row.recommended_hook),
+    caveats: toStr(row.caveats),
+    assessedDate: toStr(row.assessed_date),
+    reviewStatus: toStr(row.review_status),
+    firstFlaggedDate: toStr(row.first_flagged_date),
+  };
+}
+
+/**
+ * Activity Comments are stored as CRM rich text — tags, entities and inline
+ * styles. Strip to plain text so the brief reads as prose. This is cosmetic
+ * only: React escapes the string either way, so it is not a sanitizer.
+ */
+export function stripHtml(value) {
+  const raw = toStr(value);
+  if (!raw) return null;
+  const text = raw
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|tr|h[1-6])>/gi, '\n')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return text || null;
+}
+
+/** Convert a raw Activity row into a typed camelCase activity. */
+export function normalizeActivityRow(row) {
+  return {
+    recordId: toInt(row.RecordID),
+    date: toStr(row.occurred_on),
+    type: toStr(row.ActivityType),
+    status: toStr(row.ActivityStatus),
+    agentId: toInt(row.AssignedToRecordID),
+    notes: stripHtml(row.Comments),
   };
 }
 
@@ -226,6 +406,11 @@ export async function fetchBook(consultant, { query = queryBqWithRetry } = {}) {
   return rows.map(normalizeSnapshotRow);
 }
 
+export async function fetchPrepHistory(consultant, { query = queryBqWithRetry, limit } = {}) {
+  const { rows } = await query(buildPrepHistorySql(consultant, limit));
+  return rows.map(normalizeSnapshotRow);
+}
+
 export async function fetchAccountSnapshots(recordId, { query = queryBqWithRetry } = {}) {
   const { rows } = await query(buildAccountSnapshotsSql(recordId));
   return rows.map(normalizeSnapshotRow);
@@ -244,4 +429,43 @@ export async function fetchAccountCases(recordId, { query = queryBqWithRetry } =
 export async function fetchAccountOverview(recordId, { query = queryBqWithRetry } = {}) {
   const { rows } = await query(buildAccountOverviewSql(recordId));
   return normalizeAccountOverview(rows[0]);
+}
+
+export async function fetchAccountOpportunityFit(recordId, { query = queryBqWithRetry } = {}) {
+  const { rows } = await query(buildAccountOpportunityFitSql(recordId));
+  return rows.map(normalizeOpportunityFitRow);
+}
+
+export async function fetchAccountActivities(recordId, { query = queryBqWithRetry, limit } = {}) {
+  const { rows } = await query(buildAccountActivitiesSql(recordId, limit));
+  return rows.map(normalizeActivityRow);
+}
+
+// Reading order for the fit table, matching the brief's Opportunity Fit section.
+export const MOTION_ORDER = ['method_pay', 'dep', 'ppu', 'free_hour'];
+
+export const MOTION_LABELS = {
+  method_pay: 'Method Pay',
+  dep: 'DEP',
+  ppu: 'PPU',
+  free_hour: 'Free Hour',
+};
+
+/**
+ * The newest assessment per motion that the consultant could have seen on
+ * `asOfDate`. The table is append-only, so a later re-review must not rewrite
+ * the history of an older prep.
+ */
+export function latestFitByMotion(rows, asOfDate) {
+  const best = new Map();
+  for (const row of rows ?? []) {
+    if (!row.motion) continue;
+    if (asOfDate && row.assessedDate && row.assessedDate > asOfDate) continue;
+    const current = best.get(row.motion);
+    if (!current || (row.assessedDate ?? '') > (current.assessedDate ?? '')) best.set(row.motion, row);
+  }
+  return MOTION_ORDER
+    .map((motion) => best.get(motion))
+    .filter(Boolean)
+    .concat([...best.values()].filter((r) => !MOTION_ORDER.includes(r.motion)));
 }

--- a/builder/src/lib/googleCalendar.js
+++ b/builder/src/lib/googleCalendar.js
@@ -1,0 +1,304 @@
+// Google Calendar read layer for the call-prep week strip.
+//
+// Read-only, and only ever the signed-in user's own primary calendar. Reading a
+// teammate's calendar would need their address plus a sharing grant we don't
+// have, so /call-prep/:consultant hides the strip when you're looking at
+// someone else's book.
+//
+// Why this exists at all: call_prep.snapshots knows WHICH accounts you're
+// talking to on a given day but not WHEN — call_prep.brief_content was the only
+// source of clock times and stopped being written on 2026-07-16. The calendar
+// supplies the times, the snapshots supply the prep.
+
+import { getBqToken } from './bigquery.js';
+import { localIsoDate } from './psOverview.js';
+import { MOCK_MODE } from '../dev/mockMode.js';
+import { mockCalendarEvents, mockCalendarList } from '../dev/mockCalendar.js';
+
+// Re-exported so calendar consumers don't reach into the PS overview layer for
+// a date helper. One implementation, two entry points.
+export { localIsoDate };
+
+const CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3';
+const eventsUrl = (calendarId) =>
+  `${CALENDAR_BASE}/calendars/${encodeURIComponent(calendarId)}/events`;
+const CALENDAR_LIST_URL = `${CALENDAR_BASE}/users/me/calendarList`;
+
+/** Thrown when the stored token predates the calendar scope, or consent was declined. */
+export class CalendarScopeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CalendarScopeError';
+  }
+}
+
+/** Thrown when the calendar exists but this user can't read it. */
+export class CalendarAccessError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CalendarAccessError';
+  }
+}
+
+/** Monday of the week containing `date`, as a Date at local midnight. */
+export function startOfWeek(date = new Date()) {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dow = (d.getDay() + 6) % 7; // Monday = 0
+  d.setDate(d.getDate() - dow);
+  return d;
+}
+
+export function addDays(date, n) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+/** The `days` consecutive dates starting at `start`, as YYYY-MM-DD. */
+export function weekDays(start, days = 5) {
+  return Array.from({ length: days }, (_, i) => localIsoDate(addDays(start, i)));
+}
+
+/**
+ * A calendar event flattened to what the strip renders. All-day events carry a
+ * `date` instead of a `dateTime`; both normalize to a local YYYY-MM-DD day so
+ * grouping by column never has to care which it was.
+ */
+export function normalizeEvent(raw) {
+  const startRaw = raw?.start?.dateTime || raw?.start?.date || null;
+  const allDay = !raw?.start?.dateTime;
+  const startDate = startRaw ? new Date(startRaw) : null;
+  return {
+    id: raw?.id ?? null,
+    title: raw?.summary ?? '(no title)',
+    day: allDay ? String(startRaw).slice(0, 10) : localIsoDate(startDate),
+    startsAt: allDay ? null : startDate,
+    allDay,
+    attendees: (raw?.attendees ?? [])
+      .map((a) => String(a?.email ?? '').toLowerCase())
+      .filter(Boolean),
+    htmlLink: raw?.htmlLink ?? null,
+    declined: (raw?.attendees ?? []).some((a) => a?.self && a?.responseStatus === 'declined'),
+  };
+}
+
+/** "9:00 AM", or "All day". */
+export function formatEventTime(event) {
+  if (!event.startsAt) return 'All day';
+  return event.startsAt.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+/**
+ * GET a Calendar API URL, mapping the failure modes onto distinct errors.
+ *
+ * `ownAccess` says whether the resource is inherently the signed-in user's (their
+ * own calendar, their own subscription list) or someone else's calendar. It only
+ * decides the fallback when Google's message is unrecognizable: on your own
+ * resource an ambiguous 403 is almost always the token missing the scope, and on
+ * a teammate's calendar it's almost always sharing.
+ */
+async function calendarGet(url, fetchImpl, { ownAccess = true } = {}) {
+  const token = getBqToken();
+  if (!token) throw new CalendarScopeError('Not connected to Google');
+
+  const res = await fetchImpl(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (res.ok) return res.json();
+
+  // A 403 is three different problems wearing one status code, and only one of
+  // them is fixed by re-consenting:
+  //   - missing scope                → CalendarScopeError, show the Connect button
+  //   - API off in the Cloud console → plain Error; clicking Connect loops forever
+  //   - can't read that calendar     → CalendarAccessError, sharing fixes it, not us
+  const detail = await res.json().catch(() => null);
+  const message = detail?.error?.message || `Calendar request failed (${res.status})`;
+  if (res.status === 404) throw new CalendarAccessError(message);
+  if (res.status === 401 || res.status === 403) {
+    if (/has not been used in project|accessNotConfigured|API has not been/i.test(message)) {
+      throw new Error(message);
+    }
+    if (/scope|insufficient authentication|credential/i.test(message)) {
+      throw new CalendarScopeError('Calendar access not granted');
+    }
+    throw ownAccess ? new CalendarScopeError('Calendar access not granted') : new CalendarAccessError(message);
+  }
+  throw new Error(message);
+}
+
+/**
+ * Events between two local dates, inclusive of `fromIso`, inclusive of `toIso`.
+ * Singles and recurring instances both come back expanded. `calendarId` defaults
+ * to the signed-in user's own calendar; pass a teammate's address to read theirs,
+ * which works only where they've shared it and you're subscribed.
+ */
+export async function fetchCalendarEvents(
+  fromIso,
+  toIso,
+  { fetchImpl = fetch, calendarId = 'primary' } = {}
+) {
+  if (MOCK_MODE) return mockCalendarEvents(fromIso, toIso, calendarId).map(normalizeEvent);
+
+  const timeMin = new Date(`${fromIso}T00:00:00`).toISOString();
+  const timeMax = new Date(`${toIso}T23:59:59`).toISOString();
+  const url = `${eventsUrl(calendarId)}?${new URLSearchParams({
+    timeMin,
+    timeMax,
+    singleEvents: 'true',
+    orderBy: 'startTime',
+    maxResults: '250',
+  })}`;
+
+  const body = await calendarGet(url, fetchImpl, { ownAccess: calendarId === 'primary' });
+  return (body.items ?? []).map(normalizeEvent);
+}
+
+/**
+ * The calendars this user is subscribed to and can at least read. This is what
+ * makes a teammate's book viewable: we never guess an address, we only offer
+ * what Google already says is visible.
+ */
+export async function fetchCalendarList({ fetchImpl = fetch } = {}) {
+  if (MOCK_MODE) return mockCalendarList();
+
+  const url = `${CALENDAR_LIST_URL}?${new URLSearchParams({
+    minAccessRole: 'reader',
+    showHidden: 'true',
+    maxResults: '250',
+  })}`;
+  const body = await calendarGet(url, fetchImpl);
+  return (body.items ?? []).map((c) => ({
+    id: c.id,
+    summary: c.summary ?? '',
+    primary: Boolean(c.primary),
+  }));
+}
+
+/**
+ * Find the calendar belonging to a consultant named like `consultant`.
+ *
+ * The snapshots feed writes both "Sherry Zarei" and "S. Zarei", and a Google
+ * calendar is titled either with a display name or just an address, so this
+ * matches on first-initial + last name across both the title and the address —
+ * the same fuzziness consultantPatternFromEmail applies in the other direction.
+ */
+export function matchCalendarForConsultant(consultant, calendars) {
+  const words = normalizeText(consultant).split(' ').filter(Boolean);
+  if (words.length < 2) return null;
+  const initial = words[0][0];
+  const last = words[words.length - 1];
+  if (!initial || last.length < 2) return null;
+
+  const nameMatches = (value) => {
+    const parts = normalizeText(value).split(' ').filter(Boolean);
+    if (parts.length < 2) return false;
+    return parts[0][0] === initial && parts[parts.length - 1] === last;
+  };
+
+  for (const cal of calendars) {
+    if (cal.primary) continue;
+    const local = String(cal.id || '').split('@')[0];
+    if (nameMatches(cal.summary) || nameMatches(local)) return cal;
+  }
+  return null;
+}
+
+// ── Event → account matching ────────────────────────────────────────────────
+// There is no calendar id on an account and no domain column on int_accounts
+// (checked 2026-08-10), so matching is a heuristic over the event title and the
+// attendee list. It is tuned to under-match rather than over-match: a wrong
+// account on a prep button is worse than an event the rep has to place himself.
+
+// Words that carry no identifying signal, so they can't be the thing that
+// matches an event to an account.
+const STOPWORDS = new Set([
+  'inc', 'llc', 'ltd', 'limited', 'co', 'company', 'corp', 'corporation', 'the',
+  'and', 'of', 'group', 'holdings', 'holding', 'services', 'service', 'solutions',
+  'systems', 'enterprises', 'industries', 'international', 'partners', 'associates',
+  'products', 'supply', 'supplies', 'distribution', 'distributing', 'call', 'method',
+]);
+
+// Mailbox providers and our own domain — an attendee at one of these says
+// nothing about which account the meeting is with.
+const GENERIC_DOMAINS = new Set([
+  'gmail', 'googlemail', 'outlook', 'hotmail', 'live', 'yahoo', 'aol', 'icloud',
+  'me', 'msn', 'comcast', 'method', 'protonmail', 'zoom',
+]);
+
+const MIN_TOKEN = 5;
+
+function normalizeText(value) {
+  return String(value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+/** The distinctive words in an account name, longest first. */
+export function accountTokens(name) {
+  return normalizeText(name)
+    .split(' ')
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    .sort((a, b) => b.length - a.length);
+}
+
+/** "sarah@acme-dist.co.uk" → "acme dist". Generic providers return null. */
+function domainLabel(email) {
+  const host = String(email).split('@')[1];
+  if (!host) return null;
+  const label = host.split('.')[0];
+  if (!label || GENERIC_DOMAINS.has(label)) return null;
+  return normalizeText(label);
+}
+
+/**
+ * Best account for one event, or null. Returns the matched account plus how it
+ * was matched, so the UI can be more careful about a domain-only guess.
+ */
+export function matchEvent(event, accounts) {
+  const title = normalizeText(event.title);
+  if (!title) return null;
+
+  let best = null;
+  const consider = (account, via, weight) => {
+    if (!best || weight > best.weight) best = { account, via, weight };
+  };
+
+  for (const account of accounts) {
+    const full = normalizeText(account.accountName);
+    if (!full) continue;
+
+    // Whole account name in the title — the only unambiguous signal.
+    if (full.length >= 3 && title.includes(full)) {
+      consider(account, 'title', 1000 + full.length);
+      continue;
+    }
+
+    const tokens = accountTokens(account.accountName);
+    const titleWords = new Set(title.split(' '));
+    const hit = tokens.find((t) => t.length >= MIN_TOKEN && titleWords.has(t));
+    if (hit) {
+      consider(account, 'title', 500 + hit.length);
+      continue;
+    }
+
+    // Attendee domain against the account's distinctive words. Containment in
+    // either direction catches "Acme Distributing" ↔ acmedist.com.
+    for (const email of event.attendees) {
+      const label = domainLabel(email);
+      if (!label) continue;
+      const domainHit = tokens.find(
+        (t) => t.length >= MIN_TOKEN && (label.includes(t) || t.includes(label))
+      );
+      if (domainHit) {
+        consider(account, 'attendee', 100 + domainHit.length);
+        break;
+      }
+    }
+  }
+  return best ? { account: best.account, via: best.via } : null;
+}
+
+/**
+ * Attach `match` to every event. Callers decide what to do with the unmatched
+ * ones — the strip hides them behind a count rather than dropping them silently,
+ * because the heuristic above is the most likely thing here to be wrong.
+ */
+export function matchEvents(events, accounts) {
+  return events.map((event) => ({ ...event, match: matchEvent(event, accounts) }));
+}

--- a/builder/src/pages/CallPrep.jsx
+++ b/builder/src/pages/CallPrep.jsx
@@ -1,48 +1,100 @@
-// Call Prep — consultant picker. Route: #/call-prep
-// Lists consultants found in call_prep.snapshots; remembers the last
-// selection so returning users land one click from their book.
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+// Call Prep — consultant directory. Route: #/call-prep
+// Lists consultants found in call_prep.snapshots as a searchable table.
+//
+// The signed-in rep sorts to the top rather than being auto-opened: the
+// snapshots feed writes two name conventions for the same person ("Sherry
+// Zarei" and "S. Zarei" are both in the table), so a single rep can own more
+// than one row and there is no safe row to redirect to. Matching reuses the
+// same fuzzy email→name pattern the /ps board uses.
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { fetchConsultants } from '../lib/callPrep';
-
-const CONSULTANT_KEY = 'method_callprep_consultant';
+import { consultantPatternFromEmail } from '../lib/psOverview';
+import { useUser } from '../contexts/UserContext';
 
 const s = {
-  wrap: { maxWidth: 720, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
-  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a', marginBottom: 4 },
-  sub: { fontSize: 14, color: '#6b7280', marginBottom: 28 },
-  row: {
-    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-    padding: '14px 16px', border: '1px solid #e2e5e9', borderRadius: 8,
-    marginBottom: 8, cursor: 'pointer', background: '#fff',
+  wrap: { maxWidth: 860, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
+  title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a', marginBottom: 20 },
+
+  searchRow: { marginBottom: 20 },
+  label: {
+    display: 'block', fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+    fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase',
+    color: '#6b7280', marginBottom: 6,
   },
-  rowName: { fontSize: 15, fontWeight: 600, color: '#1a1a1a' },
-  rowMeta: { fontSize: 12, color: '#8a9099', fontFamily: "'JetBrains Mono', monospace" },
+  input: {
+    width: '100%', maxWidth: 320, padding: '8px 10px', fontSize: 14,
+    fontFamily: "'DM Sans', sans-serif", color: '#1a1a1a',
+    border: '1px solid #e2e5e9', borderRadius: 6, background: '#fff',
+  },
+
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 14 },
+  th: {
+    textAlign: 'left', padding: '8px 12px', fontSize: 10, fontWeight: 700,
+    letterSpacing: '.12em', textTransform: 'uppercase', color: '#6b7280',
+    fontFamily: "'JetBrains Mono', monospace", borderBottom: '1px solid #e2e5e9',
+  },
+  thNum: { textAlign: 'right' },
+  td: { padding: '12px', borderBottom: '1px solid #f0f1f3', color: '#1a1a1a' },
+  tdNum: { textAlign: 'right', fontFamily: "'JetBrains Mono', monospace", fontSize: 13 },
+  rowClickable: { cursor: 'pointer' },
+  name: { fontWeight: 600, color: '#1a1a1a', textDecoration: 'none' },
+  you: {
+    display: 'inline-block', marginLeft: 8, fontSize: 11, fontWeight: 600,
+    color: '#047857', background: '#ecfdf5', border: '1px solid #a7f3d0',
+    borderRadius: 4, padding: '1px 6px', verticalAlign: 'middle',
+  },
+
   note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
+  srOnly: {
+    position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
+    overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0,
+  },
   error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+  clear: {
+    background: 'none', border: 'none', padding: 0, marginLeft: 6,
+    color: '#047857', fontSize: 14, fontFamily: "'DM Sans', sans-serif",
+    cursor: 'pointer', textDecoration: 'underline',
+  },
 };
+
+/** Match a consultant name against the signed-in rep's email. */
+function makeIsMe(email) {
+  const pattern = consultantPatternFromEmail(email);
+  if (!pattern) return () => false;
+  const re = new RegExp(pattern);
+  return (name) => re.test(String(name || '').toLowerCase().trim());
+}
 
 export default function CallPrep() {
   const navigate = useNavigate();
+  const { currentUser } = useUser();
   const [consultants, setConsultants] = useState(null);
   const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
-    // Returning user: skip the picker.
-    const remembered = localStorage.getItem(CONSULTANT_KEY);
-    if (remembered) {
-      navigate(`/call-prep/${encodeURIComponent(remembered)}`, { replace: true });
-      return;
-    }
+    let cancelled = false;
     fetchConsultants()
-      .then(setConsultants)
-      .catch((e) => setError(e?.message || String(e)));
-  }, [navigate]);
+      .then((c) => { if (!cancelled) setConsultants(c); })
+      .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
+    return () => { cancelled = true; };
+  }, []);
 
-  const pick = (name) => {
-    localStorage.setItem(CONSULTANT_KEY, name);
-    navigate(`/call-prep/${encodeURIComponent(name)}`);
-  };
+  const rows = useMemo(() => {
+    if (!consultants) return [];
+    const isMe = makeIsMe(currentUser?.email);
+    return consultants
+      .map((c) => ({ ...c, isMe: isMe(c.consultant) }))
+      .sort((a, b) => (b.isMe - a.isMe) || (a.consultant ?? '').localeCompare(b.consultant ?? ''));
+  }, [consultants, currentUser]);
+
+  const term = search.trim().toLowerCase();
+  const visible = term
+    ? rows.filter((r) => (r.consultant ?? '').toLowerCase().includes(term))
+    : rows;
+
+  const open = (name) => navigate(`/call-prep/${encodeURIComponent(name)}`);
 
   if (error) {
     return (
@@ -63,15 +115,58 @@ export default function CallPrep() {
   return (
     <div style={s.wrap}>
       <h1 style={s.title}>Call Prep</h1>
-      <p style={s.sub}>Pick your name to see your accounts. We’ll remember it next time.</p>
-      {consultants.map((c) => (
-        <div key={c.consultant} style={s.row} onClick={() => pick(c.consultant)}>
-          <span style={s.rowName}>{c.consultant}</span>
-          <span style={s.rowMeta}>
-            {c.accountCount} account{c.accountCount === 1 ? '' : 's'} · last snapshot {c.lastSnapshotDate}
-          </span>
+
+      <div style={s.searchRow}>
+        <label htmlFor="consultant-search" style={s.label}>Search</label>
+        <input
+          id="consultant-search"
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={s.input}
+        />
+      </div>
+
+      {/* The table filters as you type with no on-screen count; this is the
+          only announcement a screen-reader user gets. */}
+      <p style={s.srOnly} role="status" aria-live="polite">
+        {visible.length} {visible.length === 1 ? 'consultant' : 'consultants'}
+      </p>
+
+      {!visible.length ? (
+        <div style={s.note}>
+          No consultants match “{search.trim()}”.
+          <button type="button" style={s.clear} onClick={() => setSearch('')}>Clear search</button>
         </div>
-      ))}
+      ) : (
+        <table style={s.table} aria-label="Consultants">
+          <thead>
+            <tr>
+              <th scope="col" style={s.th}>Consultant</th>
+              <th scope="col" style={{ ...s.th, ...s.thNum }}>Accounts</th>
+              <th scope="col" style={s.th}>Last snapshot</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((c) => (
+              <tr key={c.consultant} style={s.rowClickable} onClick={() => open(c.consultant)}>
+                <td style={s.td}>
+                  <Link
+                    to={`/call-prep/${encodeURIComponent(c.consultant)}`}
+                    style={s.name}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {c.consultant}
+                  </Link>
+                  {c.isMe && <span style={s.you}>You</span>}
+                </td>
+                <td style={{ ...s.td, ...s.tdNum }}>{c.accountCount}</td>
+                <td style={s.td}>{c.lastSnapshotDate ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/builder/src/pages/CallPrepAccount.jsx
+++ b/builder/src/pages/CallPrepAccount.jsx
@@ -1,84 +1,204 @@
-// Call Prep — account snapshot. Route: #/call-prep/account/:recordId
-// A one-page pre-call brief: dep_signals prose is the body; a jump-nav lets
-// the consultant snap between Situation / Timeline / Details without hiding
-// anything. The timeline is the account's real session history from
-// revenue.TimeTracking. All content is sourced from BigQuery — no doc read.
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases, fetchAccountOverview, computeFlags } from '../lib/callPrep';
+// Call Prep — account brief. Route: #/call-prep/account/:recordId
+//
+// This screen is the on-screen twin of the /call-prep skill's Google Doc
+// (method-ps-skills/commands/call-prep.md). Section order and naming follow that
+// template so a consultant reading the doc and the screen sees the same brief:
+//
+//   header identity → Top 3 points → Why today → Opportunity fit →
+//   DEP signals → Time tracking → Cases → Recent activities   (main column)
+//   Business context → Snapshot → Revenue & licenses          (rail)
+//   Details                                                   (full width)
+//
+// Template sections with no column behind them are omitted rather than stubbed:
+// Discovery Questions (generated per call, never persisted), recurring TT
+// topics, the calendar note, and the app-routine and payments health flags are
+// not in BigQuery today. The prose sections come from call_prep.brief_content,
+// which only covers 24 preps and stopped being written on 2026-07-16 —
+// everything degrades to "not recorded" without it.
+//
+// Width and zoom are user-controlled and persisted: the brief is read on a wide
+// monitor during a call and on a laptop before one, and a fixed measure serves
+// neither well.
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  fetchAccountSnapshots, fetchAccountSessions, fetchAccountCases, fetchAccountOverview,
+  fetchAccountOpportunityFit, fetchAccountActivities, latestFitByMotion, computeFlags,
+  MOTION_LABELS, ACTIVITY_LIMIT,
+} from '../lib/callPrep';
 
 const PAPER = '#faf8f3';
+const SHEET = '#fffdf8';
 const INK = '#1c1a15';
-const MUTE = '#6f6a5d';
-const FAINT = '#a8a294';
+const MUTE = '#5a5546';   // 7.3:1 on the sheet. Labels, meta, secondary values.
+const HAIR = '#8c8677';   // decorative only: rules, neutral dots
 const RULE = '#e6e1d5';
 const ACCENT = '#1b5e43';
 const AMBER = '#a85a1a';
 
+// Reading widths. "Full" tracks the viewport; the other two are fixed measures.
+const WIDTHS = [
+  { key: 'narrow', label: 'Narrow', max: 880 },
+  { key: 'wide', label: 'Wide', max: 1320 },
+  { key: 'full', label: 'Full', max: null },
+];
+const ZOOM_MIN = 80;
+const ZOOM_MAX = 150;
+const ZOOM_STEP = 10;
+const TOOLBAR_H = 46;
+const NAV_H = 44;          // the jump-nav strip, measured at 100% zoom
+const VISIBLE_SESSIONS = 6;
+
+const WIDTH_KEY = 'callPrep.width';
+const ZOOM_KEY = 'callPrep.zoom';
+const COLLAPSED_KEY = 'callPrep.collapsed';
+
 const s = {
-  stage: { background: PAPER, minHeight: '100%', padding: '32px 20px 72px', fontFamily: "'DM Sans', sans-serif" },
-  sheet: {
-    maxWidth: 720, margin: '0 auto', background: '#fffdf8',
-    border: `1px solid ${RULE}`, borderTop: `3px solid ${ACCENT}`,
-    borderRadius: 3, padding: '30px 40px 40px',
-    boxShadow: '0 1px 2px rgba(28,26,21,.04), 0 12px 34px -18px rgba(28,26,21,.22)',
+  stage: { background: PAPER, minHeight: '100%', fontFamily: "'DM Sans', sans-serif", paddingBottom: 72 },
+
+  toolbar: {
+    position: 'sticky', top: 0, zIndex: 20, height: TOOLBAR_H, boxSizing: 'border-box',
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16,
+    padding: '0 22px', background: 'rgba(250,248,243,.94)', backdropFilter: 'blur(6px)',
+    borderBottom: `1px solid ${RULE}`,
   },
-  topRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 26 },
-  crumb: { fontSize: 12.5, color: ACCENT, cursor: 'pointer', fontWeight: 500, textDecoration: 'none' },
+  toolbarGroup: { display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 },
+  crumb: {
+    fontSize: 12.5, color: ACCENT, fontWeight: 500, background: 'none', border: 'none',
+    padding: 0, cursor: 'pointer', fontFamily: "'DM Sans', sans-serif", whiteSpace: 'nowrap',
+  },
+  controlLabel: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
+    letterSpacing: '.14em', textTransform: 'uppercase', color: MUTE,
+  },
+  segment: { display: 'flex', border: `1px solid ${RULE}`, borderRadius: 5, overflow: 'hidden', background: SHEET },
+  segmentBtn: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, padding: '4px 10px',
+    border: 'none', borderLeft: `1px solid ${RULE}`, background: 'transparent',
+    color: MUTE, cursor: 'pointer',
+  },
+  segmentOn: { background: '#e8f0ea', color: ACCENT, fontWeight: 600 },
+  stepBtn: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 13, lineHeight: 1, width: 24, height: 24,
+    border: `1px solid ${RULE}`, borderRadius: 4, background: SHEET, color: INK, cursor: 'pointer',
+  },
+  zoomValue: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: INK,
+    minWidth: 38, textAlign: 'center',
+  },
   select: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5, padding: '4px 8px',
-    borderRadius: 4, border: `1px solid ${RULE}`, background: PAPER, color: INK, cursor: 'pointer',
+    borderRadius: 4, border: `1px solid ${RULE}`, background: SHEET, color: INK, cursor: 'pointer',
   },
-  dateStamp: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5, color: FAINT, letterSpacing: '.04em' },
+
+  shellOuter: { padding: '26px 22px 0' },
+  sheet: {
+    margin: '0 auto', background: SHEET, border: `1px solid ${RULE}`, borderTop: `3px solid ${ACCENT}`,
+    borderRadius: 3, padding: '30px 38px 40px',
+    boxShadow: '0 1px 2px rgba(28,26,21,.04), 0 12px 34px -18px rgba(28,26,21,.22)',
+  },
+
   kicker: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600,
     letterSpacing: '.22em', textTransform: 'uppercase', color: ACCENT, marginBottom: 12,
   },
   title: {
     fontFamily: "'Fraunces', serif", fontOpticalSizing: 'auto', fontWeight: 600,
-    fontSize: 40, lineHeight: 1.04, letterSpacing: '-.01em', color: INK, margin: '0 0 14px',
+    fontSize: 42, lineHeight: 1.04, letterSpacing: '-.01em', color: INK, margin: '0 0 12px',
   },
-  identity: { fontSize: 13.5, color: MUTE, lineHeight: 1.5, marginBottom: 14 },
-  identityStrong: { color: INK, fontWeight: 600 },
-  model: {
-    fontFamily: "'Fraunces', serif", fontStyle: 'italic', fontWeight: 400, fontSize: 17,
-    lineHeight: 1.5, color: '#39352b', margin: '0 0 4px', paddingLeft: 15,
-    borderLeft: `2px solid ${ACCENT}`,
+  when: { fontSize: 14.5, color: INK, fontWeight: 500, marginBottom: 18 },
+
+  identity: {
+    display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: '14px 26px',
+    padding: '16px 0', borderTop: `1px solid ${RULE}`, borderBottom: `1px solid ${RULE}`,
   },
-  alertRow: { display: 'flex', flexWrap: 'wrap', gap: 8, margin: '22px 0 4px' },
+  alertRow: { display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 18 },
   alert: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.02em',
     color: AMBER, background: '#fbf1e4', border: '1px solid #edd6b8', borderRadius: 3, padding: '4px 9px',
   },
+
   nav: {
-    position: 'sticky', top: 0, zIndex: 5, display: 'flex', gap: 6, flexWrap: 'wrap',
-    margin: '24px 0 4px', padding: '10px 0', background: 'rgba(255,253,248,.92)',
-    backdropFilter: 'blur(4px)', borderBottom: `1px solid ${RULE}`,
+    position: 'sticky', zIndex: 10, display: 'flex', gap: 6, flexWrap: 'wrap',
+    margin: '22px 0 6px', padding: '10px 0', background: SHEET, borderBottom: `1px solid ${RULE}`,
   },
   navChip: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.06em',
     textTransform: 'uppercase', color: MUTE, background: PAPER, border: `1px solid ${RULE}`,
-    borderRadius: 999, padding: '5px 13px', cursor: 'pointer', textDecoration: 'none',
+    borderRadius: 999, padding: '5px 13px', cursor: 'pointer',
   },
-  section: { scrollMarginTop: 56, paddingTop: 26 },
+  navChipOn: { background: '#e8f0ea', color: ACCENT, borderColor: ACCENT },
+
+  section: { paddingTop: 38 },
+
+  // Section headers. These used to be 10.5px grey mono — set smaller and lighter
+  // than the body text they introduced, which is why the page read as one flat
+  // grey column. They are now part of the document's voice (Fraunces, ink) and
+  // mono is reserved for data labels, which gives each face one job.
+  sectionMark: { width: 26, height: 3, background: ACCENT, borderRadius: 2, marginBottom: 13 },
+  sectionH: { margin: '0 0 16px' },
+  sectionBtn: {
+    display: 'flex', alignItems: 'center', gap: 12, width: '100%',
+    background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+    textAlign: 'left', fontFamily: "'DM Sans', sans-serif",
+  },
+  sectionTitle: {
+    fontFamily: "'Fraunces', serif", fontOpticalSizing: 'auto',
+    fontSize: 25, fontWeight: 600, letterSpacing: '-.005em',
+    color: INK, lineHeight: 1.15, flex: 1, minWidth: 0,
+  },
+  // A collapsed section still has to say what's inside it.
+  sectionCount: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5, fontWeight: 600,
+    color: MUTE, background: PAPER, border: `1px solid ${RULE}`,
+    borderRadius: 999, padding: '2px 10px', flexShrink: 0,
+  },
+  sectionCaret: { fontSize: 13, color: MUTE, flexShrink: 0, transition: 'transform .15s' },
+
+  // Retained for the rail cards, where a small mono label is the right register.
   bodyLabel: {
-    fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600,
-    letterSpacing: '.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 16,
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600,
+    letterSpacing: '.16em', textTransform: 'uppercase', color: MUTE, margin: '0 0 14px',
   },
+  caret: {
+    fontSize: 10, color: MUTE, display: 'inline-block', width: 10,
+    transition: 'transform .15s',
+  },
+  caretOpen: { transform: 'rotate(90deg)' },
+  empty: { fontSize: 14, color: MUTE, fontStyle: 'italic', margin: 0 },
+
+  // Top 3
+  points: { listStyle: 'none', margin: 0, padding: 0 },
+  point: {
+    position: 'relative', paddingLeft: 38, marginBottom: 16,
+    fontSize: 16, lineHeight: 1.6, color: '#2c2921',
+  },
+  pointNum: {
+    position: 'absolute', left: 0, top: 1, width: 24, height: 24, borderRadius: '50%',
+    background: '#e8f0ea', color: ACCENT, fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 12, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  prose: { fontSize: 15.5, lineHeight: 1.62, color: '#2c2921', margin: '0 0 10px' },
+
+  // DEP signals
   brief: { listStyle: 'none', margin: 0, padding: 0 },
-  briefItem: {
-    position: 'relative', paddingLeft: 24, marginBottom: 15,
-    fontSize: 15.5, lineHeight: 1.62, color: '#2c2921', maxWidth: 620,
-  },
-  briefMark: { position: 'absolute', left: 2, top: 10, width: 7, height: 7, borderRadius: '50%', background: ACCENT, opacity: .85 },
-  empty: { fontSize: 14, color: MUTE, fontStyle: 'italic' },
+  briefItem: { position: 'relative', paddingLeft: 24, marginBottom: 13, fontSize: 15, lineHeight: 1.6, color: '#2c2921' },
+  briefMark: { position: 'absolute', left: 2, top: 9, width: 7, height: 7, borderRadius: '50%', background: ACCENT, opacity: .85 },
+
+  // Stat strip
+  stats: { display: 'flex', flexWrap: 'wrap', gap: '0 34px', marginBottom: 22 },
+  statValue: { fontSize: 22, fontWeight: 600, color: INK, fontVariantNumeric: 'tabular-nums', lineHeight: 1.2 },
 
   // Timeline
   rail: { position: 'relative', margin: 0, padding: 0, listStyle: 'none' },
   railLine: { position: 'absolute', left: 7, top: 6, bottom: 6, width: 2, background: RULE },
-  event: { position: 'relative', paddingLeft: 34, marginBottom: 20 },
-  dot: { position: 'absolute', left: 2, top: 3, width: 13, height: 13, borderRadius: '50%', border: `2px solid ${PAPER}`, boxSizing: 'border-box' },
-  eventHead: { display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap', cursor: 'pointer' },
+  event: { position: 'relative', paddingLeft: 34, marginBottom: 18 },
+  dot: { position: 'absolute', left: 2, top: 4, width: 13, height: 13, borderRadius: '50%', border: `2px solid ${SHEET}`, boxSizing: 'border-box' },
+  eventHead: {
+    display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap',
+    background: 'none', border: 'none', padding: 0, textAlign: 'left', width: '100%',
+    fontFamily: "'DM Sans', sans-serif",
+  },
   eventDate: { fontFamily: "'JetBrains Mono', monospace", fontSize: 12, color: INK, fontWeight: 600 },
   typeBadge: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600, letterSpacing: '.05em',
@@ -87,52 +207,173 @@ const s = {
   eventMeta: { fontSize: 12, color: MUTE },
   eventNotes: {
     marginTop: 8, fontSize: 13.5, lineHeight: 1.55, color: '#3a362d', whiteSpace: 'pre-wrap',
-    background: PAPER, border: `1px solid ${RULE}`, borderRadius: 4, padding: '10px 13px', maxWidth: 600,
+    background: PAPER, border: `1px solid ${RULE}`, borderRadius: 4, padding: '10px 13px',
   },
-  expandHint: { fontSize: 11.5, color: ACCENT, marginTop: 3 },
+  moreBtn: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, letterSpacing: '.04em',
+    color: ACCENT, background: PAPER, border: `1px solid ${RULE}`, borderRadius: 4,
+    padding: '6px 12px', cursor: 'pointer', marginTop: 4,
+  },
+
+  // Opportunity fit
+  fitTable: { width: '100%', borderCollapse: 'collapse' },
+  fitTh: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
+    letterSpacing: '.1em', textTransform: 'uppercase', color: MUTE, textAlign: 'left',
+    padding: '0 12px 8px 0', borderBottom: `1px solid ${RULE}`,
+  },
+  fitTd: { padding: '12px 12px 12px 0', borderBottom: `1px solid ${RULE}`, verticalAlign: 'top' },
+  fitMotion: { fontSize: 14, fontWeight: 600, color: INK, whiteSpace: 'nowrap' },
+  fitBadge: {
+    display: 'inline-block', fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+    fontWeight: 700, letterSpacing: '.06em', textTransform: 'uppercase',
+    borderRadius: 3, padding: '3px 8px',
+  },
+  fitRationale: { fontSize: 13.5, lineHeight: 1.55, color: '#3a362d' },
+  fitSignals: { display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 },
+  fitSignal: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, color: MUTE,
+    background: PAPER, border: `1px solid ${RULE}`, borderRadius: 3, padding: '2px 7px',
+  },
+  caveat: {
+    marginTop: 14, fontSize: 12.5, lineHeight: 1.5, color: AMBER,
+    background: '#fbf1e4', border: '1px solid #edd6b8', borderRadius: 4, padding: '10px 13px',
+  },
+  caveatLabel: { fontWeight: 700 },
 
   // Cases
   caseRow: { padding: '12px 0', borderBottom: `1px solid ${RULE}` },
   caseTop: { display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' },
   caseSubject: { fontSize: 14.5, fontWeight: 600, color: INK },
   caseBadge: {
-    fontFamily: "'JetBrains Mono', monospace", fontSize: 9.5, fontWeight: 600, letterSpacing: '.05em',
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5, fontWeight: 600, letterSpacing: '.05em',
     textTransform: 'uppercase', borderRadius: 3, padding: '2px 7px',
   },
   caseMeta: { fontSize: 12, color: MUTE, marginTop: 3 },
 
+  // Rail cards
+  card: { background: PAPER, border: `1px solid ${RULE}`, borderRadius: 4, padding: '16px 18px', marginBottom: 16 },
+  cardRow: { display: 'flex', justifyContent: 'space-between', gap: 14, padding: '7px 0', borderTop: `1px solid ${RULE}` },
+  cardRowFirst: { borderTop: 'none', paddingTop: 0 },
+  cardKey: { fontSize: 12.5, color: MUTE, flexShrink: 0 },
+  cardVal: { fontSize: 13.5, color: INK, fontWeight: 500, textAlign: 'right', lineHeight: 1.35 },
+
   // Details grid
-  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '16px 22px' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(190px, 1fr))', gap: '16px 22px' },
   dLabel: {
     fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 600,
-    letterSpacing: '.1em', textTransform: 'uppercase', color: FAINT, marginBottom: 4,
+    letterSpacing: '.1em', textTransform: 'uppercase', color: MUTE, marginBottom: 4,
   },
   dValue: { fontSize: 14.5, fontWeight: 500, color: INK, lineHeight: 1.35 },
   dValueWarn: { color: AMBER },
 
   footer: {
-    marginTop: 32, paddingTop: 16, borderTop: `1px solid ${RULE}`,
+    marginTop: 34, paddingTop: 16, borderTop: `1px solid ${RULE}`,
     display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: 8,
   },
-  footerMeta: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: FAINT, letterSpacing: '.03em' },
-  sourceLink: { fontSize: 12, color: MUTE, textDecoration: 'none', borderBottom: `1px solid ${RULE}` },
+  footerMeta: { fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: MUTE, letterSpacing: '.03em' },
+  sourceLink: { fontSize: 12, color: ACCENT, borderBottom: `1px solid ${ACCENT}` },
+  capNote: { fontSize: 12, color: MUTE, marginTop: 12 },
   center: { maxWidth: 720, margin: '0 auto', padding: '60px 24px', textAlign: 'center', color: MUTE, fontSize: 14 },
   errorTxt: { color: '#b91c1c' },
-  timelineErr: { fontSize: 13, color: MUTE, fontStyle: 'italic' },
+  loadNote: { fontSize: 13, color: MUTE, fontStyle: 'italic', margin: 0 },
 };
 
 const CSS = `
 @keyframes cpRise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 .cp-rise { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
-.cp-brief-item { animation: cpRise .5s cubic-bezier(.2,.7,.2,1) both; }
 .cp-crumb:hover, .cp-source:hover { text-decoration: underline; }
 .cp-chip:hover { border-color: ${ACCENT}; color: ${ACCENT}; }
+.cp-sec:hover .cp-sec-title { color: ${ACCENT}; }
+.cp-sec-title { transition: color .15s; }
 .cp-event-head:hover .cp-date { color: ${ACCENT}; }
+.cp-seg-btn:first-child { border-left: none; }
+.cp-seg-btn:hover { color: ${ACCENT}; }
+.cp-step:hover:enabled { border-color: ${ACCENT}; color: ${ACCENT}; }
+.cp-step:disabled { opacity: .4; cursor: default; }
+.cp-cols { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 0 40px; align-items: start; }
+.cp-rail { position: relative; }
+@media (max-width: 1080px) {
+  .cp-cols { grid-template-columns: minmax(0, 1fr); }
+  .cp-toolbar-wrap { flex-wrap: wrap; }
+}
+button:focus-visible, select:focus-visible, a:focus-visible {
+  outline: 2px solid ${ACCENT}; outline-offset: 2px;
+}
+.cp-sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cp-rise { animation: none; }
+  .cp-caret { transition: none; }
+  * { scroll-behavior: auto !important; }
+}
 `;
+
+// Section order for the jump nav and the scroll spy. One list so a section can
+// never be in the nav but missing from the highlight, or the reverse.
+const SECTIONS = [
+  { id: 'top3', label: 'Top 3' },
+  { id: 'why', label: 'Why today' },
+  { id: 'fit', label: 'Opportunity fit' },
+  { id: 'signals', label: 'Signals' },
+  { id: 'sessions', label: 'Time tracking' },
+  { id: 'cases', label: 'Cases' },
+  { id: 'activities', label: 'Activities' },
+  { id: 'details', label: 'Details' },
+];
+
+// Fit values arrive lowercase from BigQuery. "none" needs words, not the raw
+// enum, or it reads as a missing value rather than an assessment.
+const FIT_LABELS = {
+  strong: 'Strong', moderate: 'Moderate', current: 'Current', none: 'No fit',
+};
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** "2026-08-10" → "Aug 10, 2026". Parsed as local, so the date never slips a day. */
+function fmtDate(iso) {
+  if (!iso) return null;
+  const [y, m, d] = String(iso).slice(0, 10).split('-').map(Number);
+  if (!y || !m || !d) return String(iso);
+  return `${MONTHS[m - 1]} ${d}, ${y}`;
+}
+
+function fmtWeekday(iso) {
+  if (!iso) return null;
+  const [y, m, d] = String(iso).slice(0, 10).split('-').map(Number);
+  if (!y || !m || !d) return null;
+  return DAYS[new Date(y, m - 1, d).getDay()];
+}
+
+/** scheduled_time is a BQ TIMESTAMP; show it in the reader's own timezone. */
+function fmtTime(ts) {
+  if (!ts) return null;
+  const ms = Date.parse(ts);
+  if (Number.isNaN(ms)) return null;
+  return new Date(ms).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+// Fit vocabulary from call_prep.opportunity_fit. "current" means the account is
+// already on that motion, so it reads neutral rather than as an opportunity.
+const FIT_STYLE = {
+  strong: { background: '#e8f0ea', color: ACCENT },
+  moderate: { background: '#fbf1e4', color: AMBER },
+  current: { background: '#eef2ff', color: '#3730a3' },
+  none: { background: '#f1efe8', color: MUTE },
+};
 
 function ageLabel(months) {
   if (months == null) return null;
   const m = Math.round(months);
+  // A four-week-old account reads as "0-month customer" in months. Under two
+  // months, weeks are the unit that carries the meaning.
+  if (months < 2) {
+    const weeks = Math.max(1, Math.round(months * 4.345));
+    return `~${weeks} week${weeks === 1 ? '' : 's'}`;
+  }
   if (m < 12) return `${m}-month customer`;
   const y = Math.floor(m / 12);
   const rem = m % 12;
@@ -155,7 +396,22 @@ function sessionKind(sess) {
   const t = (sess.supportType || '').toLowerCase();
   if (t === 'free') return { label: 'Free hour', bg: '#ecfdf3', fg: ACCENT, dot: ACCENT };
   if (t.includes('pay')) return { label: 'Pay-per-use', bg: '#fbf1e4', fg: AMBER, dot: AMBER };
-  return { label: sess.supportType || 'Session', bg: '#f1efe8', fg: MUTE, dot: FAINT };
+  return { label: sess.supportType || 'Session', bg: '#f1efe8', fg: MUTE, dot: HAIR };
+}
+
+/** A UI preference that survives a reload. Storage can throw in private mode. */
+function usePersisted(key, fallback, parse) {
+  const [value, setValue] = useState(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw == null ? fallback : parse(raw);
+    } catch { return fallback; }
+  });
+  const store = useCallback((next) => {
+    setValue(next);
+    try { localStorage.setItem(key, String(next)); } catch { /* preference is best-effort */ }
+  }, [key]);
+  return [value, store];
 }
 
 const Detail = ({ label, value, warn }) => (
@@ -163,6 +419,58 @@ const Detail = ({ label, value, warn }) => (
     <div style={s.dLabel}>{label}</div>
     <div style={{ ...s.dValue, ...(warn ? s.dValueWarn : null) }}>{value ?? '—'}</div>
   </div>
+);
+
+const Stat = ({ label, value }) => (
+  <div>
+    <div style={s.dLabel}>{label}</div>
+    <div style={s.statValue}>{value ?? '—'}</div>
+  </div>
+);
+
+const Row = ({ label, value, first, warn }) => (
+  <div style={{ ...s.cardRow, ...(first ? s.cardRowFirst : null) }}>
+    <span style={s.cardKey}>{label}</span>
+    <span style={{ ...s.cardVal, ...(warn ? s.dValueWarn : null) }}>{value ?? '—'}</span>
+  </div>
+);
+
+/**
+ * One brief section. The header is the disclosure control, carries the section's
+ * count so a collapsed section still reports what it holds, and is a real <h2>
+ * so the document can be navigated by heading.
+ */
+const Section = ({ id, title, count, open, onToggle, style, children }) => (
+  <section id={id} style={style}>
+    <div style={s.sectionMark} aria-hidden="true" />
+    <h2 style={s.sectionH}>
+      <button
+        type="button"
+        className="cp-sec"
+        style={s.sectionBtn}
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        <span className="cp-sec-title" style={s.sectionTitle}>{title}</span>
+        {count != null && <span style={s.sectionCount}>{count}</span>}
+        <span
+          className="cp-caret"
+          aria-hidden="true"
+          style={{ ...s.sectionCaret, ...(open ? s.caretOpen : null) }}
+        >
+          ▸
+        </span>
+      </button>
+    </h2>
+    {open ? children : null}
+  </section>
+);
+
+const Card = ({ title, children }) => (
+  <section style={s.card}>
+    <h2 style={{ ...s.bodyLabel, marginBottom: 10 }}>{title}</h2>
+    {children}
+  </section>
 );
 
 export default function CallPrepAccount() {
@@ -174,16 +482,44 @@ export default function CallPrepAccount() {
   const [sessions, setSessions] = useState(null);
   const [sessionsErr, setSessionsErr] = useState('');
   const [openEvent, setOpenEvent] = useState(null);
+  const [showAllSessions, setShowAllSessions] = useState(false);
   const [cases, setCases] = useState(null);
   const [casesErr, setCasesErr] = useState('');
   const [overview, setOverview] = useState(null);
+  const [fit, setFit] = useState(null);
+  const [fitErr, setFitErr] = useState('');
+  const [activities, setActivities] = useState(null);
+  const [activitiesErr, setActivitiesErr] = useState('');
+  const [openActivity, setOpenActivity] = useState(null);
   const sheetRef = useRef(null);
+
+  const [widthKey, setWidthKey] = usePersisted(WIDTH_KEY, 'wide', (v) => v);
+  const [zoom, setZoom] = usePersisted(ZOOM_KEY, 100, (v) => {
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, n)) : 100;
+  });
+  const width = WIDTHS.find((w) => w.key === widthKey) ?? WIDTHS[1];
+
+  // Which sections the reader has folded away, remembered between briefs — a
+  // consultant who never reads Activities shouldn't re-collapse it every call.
+  // Stored as a comma-joined list because usePersisted writes String(value).
+  const [collapsedCsv, setCollapsedCsv] = usePersisted(COLLAPSED_KEY, '', (v) => v);
+  const collapsed = useMemo(
+    () => new Set(collapsedCsv.split(',').filter(Boolean)),
+    [collapsedCsv]
+  );
+  const toggleSection = useCallback((id) => {
+    const next = new Set(collapsed);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setCollapsedCsv([...next].join(','));
+  }, [collapsed, setCollapsedCsv]);
 
   useEffect(() => {
     let cancelled = false;
     setHistory(null); setSelectedDate(null); setError('');
-    setSessions(null); setSessionsErr(''); setOpenEvent(null);
+    setSessions(null); setSessionsErr(''); setOpenEvent(null); setShowAllSessions(false);
     setCases(null); setCasesErr(''); setOverview(null);
+    setFit(null); setFitErr(''); setActivities(null); setActivitiesErr(''); setOpenActivity(null);
     fetchAccountSnapshots(recordId)
       .then((h) => { if (!cancelled) setHistory(h); })
       .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
@@ -198,6 +534,12 @@ export default function CallPrepAccount() {
     fetchAccountOverview(recordId)
       .then((o) => { if (!cancelled) setOverview(o); })
       .catch(() => { if (!cancelled) setOverview(null); });
+    fetchAccountOpportunityFit(recordId)
+      .then((rows) => { if (!cancelled) setFit(rows); })
+      .catch((e) => { if (!cancelled) setFitErr(e?.message || String(e)); });
+    fetchAccountActivities(recordId)
+      .then((rows) => { if (!cancelled) setActivities(rows); })
+      .catch((e) => { if (!cancelled) setActivitiesErr(e?.message || String(e)); });
     return () => { cancelled = true; };
   }, [recordId]);
 
@@ -209,7 +551,51 @@ export default function CallPrepAccount() {
   const todayIso = new Date().toISOString().slice(0, 10);
   const flags = useMemo(() => (snap ? computeFlags(snap, todayIso) : []), [snap, todayIso]);
 
+  // TimeTracking comes back oldest-first; the brief reads newest-first, like
+  // every other list on the page.
+  const timeline = useMemo(() => (sessions ? [...sessions].reverse() : null), [sessions]);
+  const openCases = useMemo(() => (cases ? cases.filter((c) => c.isOpen) : []), [cases]);
+
+  const fitRows = useMemo(
+    () => (fit && snap ? latestFitByMotion(fit, snap.snapshotDate) : null),
+    [fit, snap]
+  );
+  // One caveat can repeat across motions; it is a standing internal note, so
+  // show each distinct one once under the table.
+  const fitCaveats = useMemo(
+    () => [...new Set((fitRows ?? []).map((r) => r.caveats).filter(Boolean))],
+    [fitRows]
+  );
+
+  // Which section the reader is in. An eight-section sticky nav that never says
+  // where you are is decoration.
+  const [activeSection, setActiveSection] = useState(null);
+  useEffect(() => {
+    const root = sheetRef.current;
+    if (!root) return undefined;
+    const els = SECTIONS
+      .map(({ id }) => root.querySelector(`#${id}`))
+      .filter(Boolean);
+    if (!els.length) return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const showing = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (showing.length) setActiveSection(showing[0].target.id);
+      },
+      // Top inset clears the two sticky bars; the bottom inset stops a section
+      // counting as "current" while it's still only a sliver at the bottom.
+      { rootMargin: '-120px 0px -55% 0px' }
+    );
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [history]);
+
   const jump = (id) => {
+    // Jumping to a section the reader folded away would land on a bare heading,
+    // so open it on the way.
+    if (collapsed.has(id)) toggleSection(id);
     const el = sheetRef.current?.querySelector(`#${id}`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
@@ -222,7 +608,7 @@ export default function CallPrepAccount() {
     return (
       <div style={s.stage}>
         <div style={s.center}>
-          <a style={s.crumb} className="cp-crumb" onClick={() => navigate('/call-prep')}>← Call Prep</a>
+          <button type="button" style={s.crumb} className="cp-crumb" onClick={() => navigate('/call-prep')}>← Call Prep</button>
           <p style={{ marginTop: 16 }}>No snapshots exist for account {recordId} yet.</p>
         </div>
       </div>
@@ -232,211 +618,559 @@ export default function CallPrepAccount() {
   const industry = [snap.industryL1, snap.industryL2, snap.industryL3].filter(Boolean).join(' › ');
   const age = ageLabel(snap.accountAgeMonths);
   const syncWarn = (snap.syncStatus && snap.syncStatus !== 'healthy') || snap.syncFailCount > 0;
+  const callTime = fmtTime(snap.scheduledTime);
+  const weekday = fmtWeekday(snap.snapshotDate);
+  const shownSessions = timeline && !showAllSessions ? timeline.slice(0, VISIBLE_SESSIONS) : timeline;
+  const hiddenCount = timeline ? timeline.length - (shownSessions?.length ?? 0) : 0;
+  const navTop = Math.round(TOOLBAR_H / (zoom / 100));
+  // Anchor offset has to clear both sticky bars. The toolbar sits outside the
+  // zoomed container so its height needs the same correction navTop gets; the
+  // nav is inside it and doesn't.
+  const anchorOffset = navTop + NAV_H;
+  const sectionStyle = { ...s.section, scrollMarginTop: anchorOffset };
+
+  const parentLine = snap.multiEntityParentName
+    ? `Child of ${snap.multiEntityParentName}${snap.parentIsDep ? ' (parent is DEP)' : ''}`
+    : 'No';
 
   return (
     <div style={s.stage}>
       <style>{CSS}</style>
-      <div style={s.sheet} ref={sheetRef}>
-        <div style={s.topRow}>
-          <a
+
+      <div style={s.toolbar} className="cp-toolbar-wrap">
+        <div style={s.toolbarGroup}>
+          {/* Links, not buttons: these navigate, so they have to survive
+              middle-click, cmd-click and "copy link address". */}
+          <Link
             style={s.crumb}
             className="cp-crumb"
-            onClick={() => navigate(`/call-prep/${encodeURIComponent(snap.consultant || '')}`)}
+            to={`/call-prep/${encodeURIComponent(snap.consultant || '')}`}
           >
             ← {snap.consultant || 'Call Prep'}{snap.consultant ? '’s book' : ''}
-          </a>
-          <span style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            {/* This sheet is the pre-call view: one call, one date. The customer
-                page is the everything view — projects, full call history, audit
-                feedback. Cross-linked rather than merged, because they're read at
-                different moments. */}
-            <a
-              style={s.crumb}
-              className="cp-crumb"
-              onClick={() => navigate(`/accounts/${encodeURIComponent(recordId)}`)}
-            >
-              Customer view →
-            </a>
-            {history.length > 1 ? (
-              <select style={s.select} value={snap.snapshotDate} onChange={(e) => setSelectedDate(e.target.value)}>
+          </Link>
+          {/* This sheet is the pre-call view: one call, one date. The customer
+              page is the everything view — projects, full call history, audit
+              feedback. Cross-linked rather than merged, because they're read at
+              different moments. */}
+          <Link
+            style={s.crumb}
+            className="cp-crumb"
+            to={`/accounts/${encodeURIComponent(recordId)}`}
+          >
+            Customer view →
+          </Link>
+        </div>
+
+        <div style={s.toolbarGroup}>
+          {history.length > 1 && (
+            <>
+              <span style={s.controlLabel} id="cp-snapshot-label">Snapshot</span>
+              <select
+                style={s.select}
+                aria-labelledby="cp-snapshot-label"
+                value={snap.snapshotDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+              >
                 {history.map((h) => (
-                  <option key={h.snapshotDate} value={h.snapshotDate}>{h.snapshotDate}</option>
+                  <option key={h.snapshotDate} value={h.snapshotDate}>{fmtDate(h.snapshotDate)}</option>
                 ))}
               </select>
-            ) : (
-              <span style={s.dateStamp}>{snap.snapshotDate}</span>
-            )}
-          </span>
-        </div>
-
-        <div className="cp-rise"><div style={s.kicker}>{[snap.callType, 'Pre-call brief'].filter(Boolean).join(' · ')}</div></div>
-        <h1 className="cp-rise" style={{ ...s.title, animationDelay: '40ms' }}>{snap.accountName ?? '—'}</h1>
-
-        <div className="cp-rise" style={{ animationDelay: '90ms' }}>
-          <div style={s.identity}>
-            {industry ? <span style={s.identityStrong}>{industry}</span> : null}
-            {industry && (age || snap.signupDate) ? '  ·  ' : ''}
-            {age}
-            {age && snap.signupDate ? ' ' : ''}
-            {snap.signupDate ? <span>(since {snap.signupDate})</span> : null}
-            {snap.depEnrolled ? '  ·  DEP enrolled' : ''}
-            {snap.multiEntityParentName ? `  ·  child of ${snap.multiEntityParentName}` : ''}
-          </div>
-          {snap.operatingModel ? <p style={s.model}>{snap.operatingModel}</p> : null}
-        </div>
-
-        {flags.length > 0 && (
-          <div className="cp-rise" style={{ ...s.alertRow, animationDelay: '140ms' }}>
-            {flags.map((f) => <span key={f} style={s.alert}>{f}</span>)}
-          </div>
-        )}
-
-        <nav style={s.nav}>
-          <a className="cp-chip" style={s.navChip} onClick={() => jump('situation')}>Situation</a>
-          {overview ? <a className="cp-chip" style={s.navChip} onClick={() => jump('revenue')}>Revenue</a> : null}
-          <a className="cp-chip" style={s.navChip} onClick={() => jump('timeline')}>Timeline</a>
-          <a className="cp-chip" style={s.navChip} onClick={() => jump('cases')}>Cases</a>
-          <a className="cp-chip" style={s.navChip} onClick={() => jump('details')}>Details</a>
-        </nav>
-
-        <section id="situation" style={s.section}>
-          <div style={s.bodyLabel}>What’s going on</div>
-          {snap.depSignals.length > 0 ? (
-            <ul style={s.brief}>
-              {snap.depSignals.map((sig, i) => (
-                <li key={sig} className="cp-brief-item" style={{ ...s.briefItem, animationDelay: `${i * 45}ms` }}>
-                  <span style={s.briefMark} />
-                  {sig}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p style={s.empty}>No prep notes recorded for this snapshot.</p>
+            </>
           )}
-        </section>
 
-        {overview && (
-          <section id="revenue" style={s.section}>
-            <div style={s.bodyLabel}>Revenue &amp; licenses</div>
-            <div style={s.grid}>
-              <Detail label="MRR (run-rate)" value={overview.mrrRunRate != null ? `$${overview.mrrRunRate.toLocaleString()}/mo` : null} />
-              <Detail label="User licenses" value={overview.userLicenses} />
-              <Detail label="Health score" value={overview.healthScore != null ? Math.round(overview.healthScore) : null} warn={overview.healthScore != null && overview.healthScore < 50} />
-              <Detail label="Billing" value={overview.saasPayType} />
+          <span style={s.controlLabel} id="cp-width-label">Width</span>
+          <div style={s.segment} role="group" aria-labelledby="cp-width-label">
+            {WIDTHS.map((w) => (
+              <button
+                key={w.key}
+                type="button"
+                className="cp-seg-btn"
+                aria-pressed={w.key === width.key}
+                style={{ ...s.segmentBtn, ...(w.key === width.key ? s.segmentOn : null) }}
+                onClick={() => setWidthKey(w.key)}
+              >
+                {w.label}
+              </button>
+            ))}
+          </div>
+
+          <span style={s.controlLabel} id="cp-zoom-label">Zoom</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }} role="group" aria-labelledby="cp-zoom-label">
+            <button
+              type="button"
+              className="cp-step"
+              style={s.stepBtn}
+              aria-label="Zoom out"
+              disabled={zoom <= ZOOM_MIN}
+              onClick={() => setZoom(Math.max(ZOOM_MIN, zoom - ZOOM_STEP))}
+            >
+              −
+            </button>
+            <span style={s.zoomValue} aria-live="polite">{zoom}%</span>
+            <button
+              type="button"
+              className="cp-step"
+              style={s.stepBtn}
+              aria-label="Zoom in"
+              disabled={zoom >= ZOOM_MAX}
+              onClick={() => setZoom(Math.min(ZOOM_MAX, zoom + ZOOM_STEP))}
+            >
+              +
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* zoom scales the brief only; the toolbar keeps its own size so the
+          controls stay where the eye left them. */}
+      <div style={{ ...s.shellOuter, zoom: zoom / 100 }}>
+        <div style={{ ...s.sheet, maxWidth: width.max ?? '100%' }} ref={sheetRef}>
+          <div className="cp-rise"><div style={s.kicker}>{[snap.callType, 'Pre-call brief'].filter(Boolean).join(' · ')}</div></div>
+          <h1 className="cp-rise" style={{ ...s.title, animationDelay: '40ms' }}>{snap.accountName ?? '—'}</h1>
+
+          <div className="cp-rise" style={{ animationDelay: '90ms' }}>
+            <div style={s.when}>
+              {[weekday, fmtDate(snap.snapshotDate)].filter(Boolean).join(', ')}
+              {callTime ? ` @ ${callTime}` : ''}
             </div>
-            <p style={{ fontSize: 11.5, color: FAINT, marginTop: 12, fontStyle: 'italic' }}>
-              Utilization (active users ÷ licenses) pending an upstream field. MRR is a nightly run-rate proxy, not recognized revenue.
-            </p>
-          </section>
-        )}
 
-        <section id="timeline" style={s.section}>
-          <div style={s.bodyLabel}>History</div>
-          {sessionsErr ? (
-            <p style={s.timelineErr}>Couldn’t load session history.</p>
-          ) : sessions == null ? (
-            <p style={s.timelineErr}>Loading history…</p>
-          ) : (
-            <ul style={s.rail}>
-              <div style={s.railLine} />
-              {snap.signupDate && (
-                <li style={s.event}>
-                  <span style={{ ...s.dot, background: INK }} />
-                  <div style={s.eventHead}>
-                    <span style={s.eventDate}>{snap.signupDate}</span>
-                    <span style={{ ...s.typeBadge, background: '#efece3', color: INK }}>Signed up</span>
-                  </div>
-                </li>
-              )}
-              {sessions.map((sess, i) => {
-                const kind = sessionKind(sess);
-                const key = `${sess.date}-${i}`;
-                const isThisCall = sess.date === snap.snapshotDate;
-                const body = cleanNotes(sess.notes);
-                const open = openEvent === key;
-                return (
-                  <li key={key} style={s.event}>
-                    <span style={{ ...s.dot, background: kind.dot }} />
-                    <div className="cp-event-head" style={s.eventHead} onClick={() => setOpenEvent(open ? null : key)}>
-                      <span className="cp-date" style={s.eventDate}>{sess.date}</span>
-                      <span style={{ ...s.typeBadge, background: kind.bg, color: kind.fg }}>{kind.label}</span>
-                      <span style={s.eventMeta}>
-                        {sess.durationHours != null ? `${sess.durationHours} hr` : ''}
-                        {isThisCall ? '  ·  this call’s day' : ''}
-                      </span>
-                    </div>
-                    {body ? (
-                      open
-                        ? <div style={s.eventNotes}>{body}</div>
-                        : <div style={s.expandHint}>click to read notes →</div>
-                    ) : null}
-                  </li>
-                );
-              })}
-              {sessions.length === 0 && <li style={s.empty}>No sessions recorded yet.</li>}
-            </ul>
-          )}
-        </section>
-
-        <section id="cases" style={s.section}>
-          <div style={s.bodyLabel}>Cases</div>
-          {casesErr ? (
-            <p style={s.timelineErr}>Couldn’t load cases.</p>
-          ) : cases == null ? (
-            <p style={s.timelineErr}>Loading cases…</p>
-          ) : cases.length === 0 ? (
-            <p style={s.empty}>No cases on record.</p>
-          ) : (
-            <div>
-              {cases.map((c) => (
-                <div key={c.recordId} style={s.caseRow}>
-                  <div style={s.caseTop}>
-                    <span style={s.caseSubject}>{c.subject ?? `Case #${c.recordId}`}</span>
-                    <span style={{ ...s.caseBadge, ...(c.isOpen ? { background: '#fbf1e4', color: AMBER } : { background: '#f1efe8', color: MUTE }) }}>
-                      {c.status || (c.isOpen ? 'Open' : 'Closed')}
+            <div style={s.identity}>
+              <Detail
+                label="Contact"
+                value={snap.contactName || snap.contactEmail
+                  ? <span>{snap.contactName || snap.contactEmail}
+                      {snap.contactName && snap.contactEmail
+                        ? <span style={{ display: 'block', fontSize: 12.5, fontWeight: 400, color: MUTE }}>{snap.contactEmail}</span>
+                        : null}
                     </span>
-                    {c.priority ? <span style={{ ...s.caseBadge, background: '#f1efe8', color: MUTE }}>{c.priority}</span> : null}
-                  </div>
-                  <div style={s.caseMeta}>
-                    #{c.recordId} · opened {c.createdDate}
-                    {c.closedDate ? ` · closed ${c.closedDate}` : ''}
-                    {c.contactName ? ` · ${c.contactName}` : ''}
-                  </div>
-                </div>
-              ))}
+                  : null}
+              />
+              <Detail label="Consultant" value={snap.consultant} />
+              <Detail
+                label="Account age"
+                value={age
+                  ? <span>{age}
+                      {snap.signupDate
+                        ? <span style={{ display: 'block', fontSize: 12.5, fontWeight: 400, color: MUTE }}>
+                            signed up {fmtDate(snap.signupDate)}
+                          </span>
+                        : null}
+                    </span>
+                  : null}
+              />
+              <Detail label="DEP enrolled" value={snap.depEnrolled ? 'Yes' : 'No'} />
             </div>
-          )}
-        </section>
 
-        <section id="details" style={s.section}>
-          <div style={s.bodyLabel}>Details</div>
-          <div style={s.grid}>
-            <Detail label="Sync status" value={snap.syncStatus} warn={syncWarn} />
-            <Detail label="Sync failures" value={snap.syncFailCount} warn={snap.syncFailCount > 0} />
-            <Detail label="Time tracked" value={snap.ttTotalHours != null ? `${snap.ttTotalHours} hrs` : null} />
-            <Detail label="Sessions (snapshot)" value={snap.ttSessionCount} />
-            <Detail label="Last session" value={snap.ttLastSessionDate} />
-            <Detail label="Open cases" value={snap.casesOpenCount} warn={snap.casesOpenCount > 0} />
-            <Detail label="Closed cases (90d)" value={snap.casesClosed90dCount} />
-            <Detail label="Signup date" value={snap.signupDate} />
-            <Detail label="Account age" value={snap.accountAgeMonths != null ? `${snap.accountAgeMonths.toFixed(1)} mo` : null} />
-            <Detail label="DEP enrolled" value={snap.depEnrolled ? 'yes' : 'no'} />
-            {snap.multiEntityParentName ? <Detail label="Parent entity" value={snap.multiEntityParentName} /> : null}
-            <Detail label="Industry" value={industry || null} />
-            <Detail label="Operating model" value={snap.operatingModel} />
-            {snap.bqConfidence != null ? <Detail label="Classifier confidence" value={`${Math.round(snap.bqConfidence * 100)}%`} /> : null}
+            {flags.length > 0 && (
+              <div style={s.alertRow}>
+                {flags.map((f) => <span key={f} style={s.alert}>{f}</span>)}
+              </div>
+            )}
           </div>
-        </section>
 
-        <div style={s.footer}>
-          <span style={s.footerMeta}>
-            Prepared for {snap.consultant || '—'} · account #{snap.accountRecordId} · snapshot {snap.snapshotDate}
-          </span>
-          {snap.docLink ? (
-            <a style={s.sourceLink} className="cp-source" href={snap.docLink} target="_blank" rel="noreferrer">
-              source document ↗
-            </a>
-          ) : null}
+          <nav style={{ ...s.nav, top: navTop }} aria-label="Brief sections">
+            {SECTIONS.map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                className="cp-chip"
+                style={{ ...s.navChip, ...(activeSection === id ? s.navChipOn : null) }}
+                aria-current={activeSection === id ? 'true' : undefined}
+                onClick={() => jump(id)}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="cp-cols">
+            <div>
+              <Section
+                id="top3"
+                title="Top 3 points for today"
+                count={snap.top3.length || null}
+                open={!collapsed.has('top3')}
+                onToggle={() => toggleSection('top3')}
+                style={sectionStyle}
+              >
+                {snap.top3.length > 0 ? (
+                  <ol style={s.points}>
+                    {snap.top3.map((point, i) => (
+                      <li key={point} style={s.point}>
+                        <span style={s.pointNum} aria-hidden="true">{i + 1}</span>
+                        {point}
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p style={s.empty}>No points written for this prep.</p>
+                )}
+              </Section>
+
+              <Section
+                id="why"
+                title="Why today"
+                open={!collapsed.has('why')}
+                onToggle={() => toggleSection('why')}
+                style={sectionStyle}
+              >
+                {snap.whyToday ? <p style={s.prose}>{snap.whyToday}</p> : <p style={s.empty}>Not recorded for this prep.</p>}
+                {openCases.length > 0 && (
+                  <p style={{ ...s.prose, marginTop: 12 }}>
+                    <strong>Most recent open case:</strong>{' '}
+                    {openCases[0].subject ?? `Case #${openCases[0].recordId}`} — opened {fmtDate(openCases[0].createdDate)}
+                  </p>
+                )}
+              </Section>
+
+              <Section
+                id="fit"
+                title="Opportunity fit"
+                count={fitRows?.length || null}
+                open={!collapsed.has('fit')}
+                onToggle={() => toggleSection('fit')}
+                style={sectionStyle}
+              >
+                {fitErr ? (
+                  <p style={s.loadNote}>Couldn’t load opportunity fit.</p>
+                ) : fitRows == null ? (
+                  <p style={s.loadNote}>Loading opportunity fit…</p>
+                ) : fitRows.length === 0 ? (
+                  <p style={s.empty}>No motions assessed for this account yet.</p>
+                ) : (
+                  <>
+                    <table style={s.fitTable}>
+                      <caption className="cp-sr-only">
+                        Commercial motion fit for {snap.accountName}
+                      </caption>
+                      <thead>
+                        <tr>
+                          <th scope="col" style={s.fitTh}>Motion</th>
+                          <th scope="col" style={s.fitTh}>Fit</th>
+                          <th scope="col" style={s.fitTh}>Rationale</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {fitRows.map((row) => (
+                          <tr key={row.motion}>
+                            <th scope="row" style={{ ...s.fitTd, ...s.fitMotion }}>
+                              {MOTION_LABELS[row.motion] ?? row.motion}
+                            </th>
+                            <td style={s.fitTd}>
+                              <span style={{ ...s.fitBadge, ...(FIT_STYLE[row.fit] ?? FIT_STYLE.none) }}>
+                                {FIT_LABELS[row.fit] ?? 'Unknown'}
+                              </span>
+                            </td>
+                            <td style={s.fitTd}>
+                              <div style={s.fitRationale}>{row.rationale ?? '—'}</div>
+                              {row.signals.length > 0 && (
+                                <div style={s.fitSignals}>
+                                  {row.signals.map((sig) => <span key={sig} style={s.fitSignal}>{sig}</span>)}
+                                </div>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {fitCaveats.map((c) => (
+                      <p key={c} style={s.caveat}>
+                        <span style={s.caveatLabel}>Internal only.</span> {c}
+                      </p>
+                    ))}
+                  </>
+                )}
+              </Section>
+
+              <Section
+                id="signals"
+                title="DEP signals"
+                count={snap.depSignals.length || null}
+                open={!collapsed.has('signals')}
+                onToggle={() => toggleSection('signals')}
+                style={sectionStyle}
+              >
+                {snap.depSignals.length > 0 ? (
+                  <ul style={s.brief}>
+                    {snap.depSignals.map((sig) => (
+                      <li key={sig} style={s.briefItem}>
+                        <span style={s.briefMark} />
+                        {sig}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p style={s.empty}>None evident from current data.</p>
+                )}
+              </Section>
+
+              <Section
+                id="sessions"
+                title="Time tracking"
+                count={timeline?.length || null}
+                open={!collapsed.has('sessions')}
+                onToggle={() => toggleSection('sessions')}
+                style={sectionStyle}
+              >
+                <div style={s.stats}>
+                  <Stat label="Total billed" value={snap.ttTotalHours != null ? `${snap.ttTotalHours} hrs` : null} />
+                  <Stat label="Sessions" value={snap.ttSessionCount} />
+                  <Stat label="Last session" value={fmtDate(snap.ttLastSessionDate)} />
+                </div>
+                {sessionsErr ? (
+                  <p style={s.loadNote}>Couldn’t load session history.</p>
+                ) : timeline == null ? (
+                  <p style={s.loadNote}>Loading session history…</p>
+                ) : timeline.length === 0 ? (
+                  <p style={s.empty}>No sessions recorded yet.</p>
+                ) : (
+                  <div style={{ position: 'relative' }}>
+                    <span style={s.railLine} aria-hidden="true" />
+                    <ul style={s.rail}>
+                      {shownSessions.map((sess, i) => {
+                        const kind = sessionKind(sess);
+                        const key = `${sess.date}-${i}`;
+                        const isThisCall = sess.date === snap.snapshotDate;
+                        const body = cleanNotes(sess.notes);
+                        const open = openEvent === key;
+                        // Only a session that has notes is a control; the rest
+                        // are plain rows, so nothing focusable does nothing.
+                        const head = (
+                          <>
+                            {body && (
+                              <span
+                                className="cp-caret"
+                                aria-hidden="true"
+                                style={{ ...s.caret, ...(open ? s.caretOpen : null) }}
+                              >
+                                ▸
+                              </span>
+                            )}
+                            <span className="cp-date" style={s.eventDate}>{fmtDate(sess.date)}</span>
+                            <span style={{ ...s.typeBadge, background: kind.bg, color: kind.fg }}>{kind.label}</span>
+                            <span style={s.eventMeta}>
+                              {sess.durationHours != null ? `${sess.durationHours} hr` : ''}
+                              {isThisCall ? '  ·  this call’s day' : ''}
+                            </span>
+                          </>
+                        );
+                        return (
+                          <li key={key} style={s.event}>
+                            <span style={{ ...s.dot, background: kind.dot }} />
+                            {body ? (
+                              <button
+                                type="button"
+                                className="cp-event-head"
+                                style={{ ...s.eventHead, cursor: 'pointer' }}
+                                aria-expanded={open}
+                                onClick={() => setOpenEvent(open ? null : key)}
+                              >
+                                {head}
+                              </button>
+                            ) : (
+                              <div style={s.eventHead}>{head}</div>
+                            )}
+                            {body && open ? <div style={s.eventNotes}>{body}</div> : null}
+                          </li>
+                        );
+                      })}
+                      {snap.signupDate && showAllSessions && (
+                        <li style={s.event}>
+                          <span style={{ ...s.dot, background: INK }} />
+                          <div style={s.eventHead}>
+                            <span style={s.eventDate}>{fmtDate(snap.signupDate)}</span>
+                            <span style={{ ...s.typeBadge, background: '#efece3', color: INK }}>Signed up</span>
+                          </div>
+                        </li>
+                      )}
+                    </ul>
+                    {hiddenCount > 0 && (
+                      <button type="button" style={s.moreBtn} onClick={() => setShowAllSessions(true)}>
+                        Show all {timeline.length} sessions
+                      </button>
+                    )}
+                    {showAllSessions && timeline.length > VISIBLE_SESSIONS && (
+                      <button type="button" style={s.moreBtn} onClick={() => setShowAllSessions(false)}>
+                        Show recent only
+                      </button>
+                    )}
+                  </div>
+                )}
+              </Section>
+
+              <Section
+                id="cases"
+                title="Cases"
+                count={cases?.length || null}
+                open={!collapsed.has('cases')}
+                onToggle={() => toggleSection('cases')}
+                style={sectionStyle}
+              >
+                {casesErr ? (
+                  <p style={s.loadNote}>Couldn’t load cases.</p>
+                ) : cases == null ? (
+                  <p style={s.loadNote}>Loading cases…</p>
+                ) : cases.length === 0 ? (
+                  <p style={s.empty}>No cases on record.</p>
+                ) : (
+                  <div>
+                    <p style={{ ...s.eventMeta, marginTop: 0, marginBottom: 8 }}>
+                      {cases.length} on record · {openCases.length} open · {cases.length - openCases.length} closed
+                    </p>
+                    {cases.map((c) => (
+                      <div key={c.recordId} style={s.caseRow}>
+                        <div style={s.caseTop}>
+                          <span style={s.caseSubject}>{c.subject ?? `Case #${c.recordId}`}</span>
+                          <span style={{ ...s.caseBadge, ...(c.isOpen ? { background: '#fbf1e4', color: AMBER } : { background: '#f1efe8', color: MUTE }) }}>
+                            {c.status || (c.isOpen ? 'Open' : 'Closed')}
+                          </span>
+                          {c.priority ? <span style={{ ...s.caseBadge, background: '#f1efe8', color: MUTE }}>{c.priority}</span> : null}
+                        </div>
+                        <div style={s.caseMeta}>
+                          #{c.recordId} · opened {fmtDate(c.createdDate)}
+                          {c.closedDate ? ` · closed ${fmtDate(c.closedDate)}` : ''}
+                          {c.contactName ? ` · ${c.contactName}` : ''}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Section>
+
+              <Section
+                id="activities"
+                title="Recent activities"
+                count={activities?.length || null}
+                open={!collapsed.has('activities')}
+                onToggle={() => toggleSection('activities')}
+                style={sectionStyle}
+              >
+                {activitiesErr ? (
+                  <p style={s.loadNote}>Couldn’t load activities.</p>
+                ) : activities == null ? (
+                  <p style={s.loadNote}>Loading activities…</p>
+                ) : activities.length === 0 ? (
+                  <p style={s.empty}>No activities logged on this account.</p>
+                ) : (
+                  <div style={{ position: 'relative' }}>
+                    <span style={s.railLine} aria-hidden="true" />
+                    <ul style={s.rail}>
+                      {activities.map((act) => {
+                        const open = openActivity === act.recordId;
+                        const head = (
+                          <>
+                            {act.notes && (
+                              <span
+                                className="cp-caret"
+                                aria-hidden="true"
+                                style={{ ...s.caret, ...(open ? s.caretOpen : null) }}
+                              >
+                                ▸
+                              </span>
+                            )}
+                            <span className="cp-date" style={s.eventDate}>{fmtDate(act.date)}</span>
+                            <span style={{ ...s.typeBadge, background: '#f1efe8', color: MUTE }}>{act.type ?? 'Activity'}</span>
+                            <span style={s.eventMeta}>
+                              {act.agentId != null ? `agent #${act.agentId}` : ''}
+                              {act.status && act.status !== 'Completed' ? `  ·  ${act.status}` : ''}
+                            </span>
+                          </>
+                        );
+                        return (
+                          <li key={act.recordId} style={s.event}>
+                            <span style={{ ...s.dot, background: HAIR }} />
+                            {act.notes ? (
+                              <button
+                                type="button"
+                                className="cp-event-head"
+                                style={{ ...s.eventHead, cursor: 'pointer' }}
+                                aria-expanded={open}
+                                onClick={() => setOpenActivity(open ? null : act.recordId)}
+                              >
+                                {head}
+                              </button>
+                            ) : (
+                              <div style={s.eventHead}>{head}</div>
+                            )}
+                            {act.notes && open ? <div style={s.eventNotes}>{act.notes}</div> : null}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {activities.length >= ACTIVITY_LIMIT && (
+                      <p style={s.capNote}>Latest {ACTIVITY_LIMIT} activities.</p>
+                    )}
+                  </div>
+                )}
+              </Section>
+            </div>
+
+            <aside className="cp-rail" style={{ paddingTop: 38 }}>
+              <Card title="Business context">
+                <Row label="Industry" value={industry || null} first />
+                <Row label="Operating model" value={snap.operatingModel} />
+                {snap.bqConfidence != null && (
+                  <Row label="Classifier confidence" value={`${Math.round(snap.bqConfidence * 100)}%`} />
+                )}
+                {snap.website && (
+                  <Row
+                    label="Website"
+                    value={<a href={snap.website} target="_blank" rel="noreferrer" style={{ color: ACCENT }}>{snap.website.replace(/^https?:\/\//, '')}</a>}
+                  />
+                )}
+                {snap.businessContext ? <p style={{ ...s.prose, fontSize: 13.5, marginTop: 12, marginBottom: 0 }}>{snap.businessContext}</p> : null}
+              </Card>
+
+              <Card title="Snapshot">
+                <Row label="Type" value={snap.callType} first />
+                <Row label="Sync status" value={snap.syncStatus} warn={syncWarn} />
+                <Row label="Sync failures" value={snap.syncFailCount} warn={snap.syncFailCount > 0} />
+                <Row label="Open cases" value={snap.casesOpenCount} warn={snap.casesOpenCount > 0} />
+                <Row label="Multi-entity" value={parentLine} />
+              </Card>
+
+              {overview && (
+                <Card title="Revenue & licenses">
+                  <Row label="MRR (run-rate)" value={overview.mrrRunRate != null ? `$${overview.mrrRunRate.toLocaleString()}/mo` : null} first />
+                  <Row label="User licenses" value={overview.userLicenses} />
+                  <Row
+                    label="Health score"
+                    value={overview.healthScore != null ? Math.round(overview.healthScore) : null}
+                    warn={overview.healthScore != null && overview.healthScore < 50}
+                  />
+                  <Row label="Billing" value={overview.saasPayType} />
+                </Card>
+              )}
+            </aside>
+          </div>
+
+          <Section
+            id="details"
+            title="Details"
+            open={!collapsed.has('details')}
+            onToggle={() => toggleSection('details')}
+            style={sectionStyle}
+          >
+            {/* Everything not already on the page. Twelve of the original
+                fourteen entries here repeated the identity block, the stat strip
+                or a rail card verbatim, which cost a screenful of scrolling and
+                gave the eye nothing new. */}
+            <div style={s.grid}>
+              <Detail label="Closed cases (90d)" value={snap.casesClosed90dCount} />
+              {snap.contactPhone ? <Detail label="Contact phone" value={snap.contactPhone} /> : null}
+            </div>
+          </Section>
+
+          <div style={s.footer}>
+            <span style={s.footerMeta}>
+              Prepared for {snap.consultant || '—'} · account #{snap.accountRecordId} · snapshot {fmtDate(snap.snapshotDate)}
+            </span>
+            {snap.docLink ? (
+              <a style={s.sourceLink} className="cp-source" href={snap.docLink} target="_blank" rel="noreferrer">
+                source document ↗
+              </a>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/builder/src/pages/CallPrepBook.jsx
+++ b/builder/src/pages/CallPrepBook.jsx
@@ -1,107 +1,337 @@
-// Call Prep — one consultant's book. Route: #/call-prep/:consultant
-// One row per account (latest snapshot), flagged accounts sort first.
+// Call Prep — one consultant's page. Route: #/call-prep/:consultant
+//
+// Three sources, one screen:
+//   - the week strip is Google Calendar (times, this week, own calendar only)
+//   - Today / Past preps are call_prep.snapshots rows, split on snapshot_date
+//   - Accounts is the latest snapshot per account, flagged rows first
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { fetchBook, computeFlags } from '../lib/callPrep';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useUser } from '../contexts/UserContext';
+import {
+  PREP_HISTORY_LIMIT,
+  computeFlags,
+  fetchBook,
+  fetchPrepHistory,
+} from '../lib/callPrep';
+import { consultantPatternFromEmail } from '../lib/psOverview';
+import { localIsoDate } from '../lib/googleCalendar';
+import WeekStrip from '../components/callprep/WeekStrip';
 
-const CONSULTANT_KEY = 'method_callprep_consultant';
+const PAGE_SIZE = 50;
 
 const s = {
-  wrap: { maxWidth: 920, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
-  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 24 },
+  wrap: { maxWidth: 1040, margin: '0 auto', padding: '40px 24px', fontFamily: "'DM Sans', sans-serif" },
+  head: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 20, gap: 16 },
+  kicker: {
+    fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 700,
+    letterSpacing: '.14em', textTransform: 'uppercase', color: '#6b7280', marginBottom: 4,
+  },
   title: { fontSize: 22, fontWeight: 700, color: '#1a1a1a' },
-  switchLink: { fontSize: 13, color: '#059669', cursor: 'pointer', textDecoration: 'underline' },
+  attention: { fontSize: 13, color: '#b45309', marginBottom: 16 },
+  srOnly: {
+    position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
+    overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0,
+  },
+  switchLink: { fontSize: 13, color: '#047857', textDecoration: 'underline', whiteSpace: 'nowrap' },
+
+  tabs: { display: 'flex', gap: 6, marginBottom: 16, flexWrap: 'wrap' },
+  tab: {
+    padding: '6px 14px', fontSize: 13, fontFamily: "'DM Sans', sans-serif",
+    color: '#374151', background: '#fff', border: '1px solid #e2e5e9',
+    borderRadius: 6, cursor: 'pointer',
+  },
+  tabActive: { color: '#fff', background: '#047857', borderColor: '#047857', fontWeight: 600 },
+
+  searchRow: { marginBottom: 16 },
+  label: {
+    display: 'block', fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+    fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase',
+    color: '#6b7280', marginBottom: 6,
+  },
+  input: {
+    width: '100%', maxWidth: 320, padding: '8px 10px', fontSize: 14,
+    fontFamily: "'DM Sans', sans-serif", color: '#1a1a1a',
+    border: '1px solid #e2e5e9', borderRadius: 6, background: '#fff',
+  },
+
   table: { width: '100%', borderCollapse: 'collapse', fontSize: 14 },
   th: {
     textAlign: 'left', padding: '8px 12px', fontSize: 10, fontWeight: 700,
-    letterSpacing: '.12em', textTransform: 'uppercase', color: '#8a9099',
+    letterSpacing: '.12em', textTransform: 'uppercase', color: '#6b7280',
     fontFamily: "'JetBrains Mono', monospace", borderBottom: '1px solid #e2e5e9',
   },
+  thNum: { textAlign: 'right' },
   td: { padding: '12px', borderBottom: '1px solid #f0f1f3', color: '#1a1a1a' },
+  tdNum: { textAlign: 'right', fontFamily: "'JetBrains Mono', monospace", fontSize: 13 },
+  tdDate: { fontFamily: "'JetBrains Mono', monospace", fontSize: 13, color: '#6b7280' },
   rowClickable: { cursor: 'pointer' },
+  name: { fontWeight: 600, color: '#1a1a1a', textDecoration: 'none' },
+
   flag: {
     display: 'inline-block', fontSize: 11, fontWeight: 600, color: '#b45309',
     background: '#fffbeb', border: '1px solid #fde68a', borderRadius: 4,
     padding: '2px 8px', marginRight: 6,
   },
-  ok: { fontSize: 12, color: '#059669' },
+  ok: { fontSize: 12, color: '#047857' },
+
+  more: { marginTop: 14, display: 'flex', alignItems: 'center', gap: 12 },
+  moreBtn: {
+    padding: '6px 14px', fontSize: 13, fontFamily: "'DM Sans', sans-serif",
+    color: '#374151', background: '#fff', border: '1px solid #e2e5e9',
+    borderRadius: 6, cursor: 'pointer',
+  },
+  count: { fontSize: 12, color: '#6b7280' },
   note: { fontSize: 14, color: '#6b7280', padding: 24, textAlign: 'center' },
   error: { fontSize: 14, color: '#b91c1c', padding: 24, textAlign: 'center' },
+  clear: {
+    background: 'none', border: 'none', padding: 0, marginLeft: 6,
+    color: '#047857', fontSize: 14, fontFamily: "'DM Sans', sans-serif",
+    cursor: 'pointer', textDecoration: 'underline',
+  },
 };
+
+const TABS = [
+  { id: 'today', label: 'Today' },
+  { id: 'past', label: 'Past preps' },
+  { id: 'accounts', label: 'Accounts' },
+];
+
+/**
+ * normalizeSnapshotRow lowercases sync_status so comparisons elsewhere can rely
+ * on it. Presentation is this layer's job, not the store's.
+ */
+function sentenceCase(value) {
+  if (!value) return '—';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/** Does this consultant name belong to the signed-in user? */
+function isOwnBook(consultant, email) {
+  const pattern = consultantPatternFromEmail(email);
+  if (!pattern) return false;
+  return new RegExp(pattern).test(String(consultant || '').toLowerCase().trim());
+}
+
+function AccountCell({ snap }) {
+  return (
+    <Link
+      to={`/call-prep/account/${encodeURIComponent(snap.accountRecordId)}`}
+      style={s.name}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {snap.accountName}
+    </Link>
+  );
+}
+
+function Flags({ flags }) {
+  if (!flags.length) return <span style={s.ok}>ok</span>;
+  return flags.map((f) => <span key={f} style={s.flag}>{f}</span>);
+}
 
 export default function CallPrepBook() {
   const { consultant } = useParams();
   const navigate = useNavigate();
+  const { currentUser } = useUser();
+
   const [book, setBook] = useState(null);
+  const [history, setHistory] = useState(null);
   const [error, setError] = useState('');
+  const [tab, setTab] = useState('today');
+  const [search, setSearch] = useState('');
+  const [limit, setLimit] = useState(PAGE_SIZE);
 
   useEffect(() => {
     let cancelled = false;
     setBook(null);
+    setHistory(null);
     setError('');
-    fetchBook(consultant)
-      .then((b) => { if (!cancelled) setBook(b); })
+    Promise.all([fetchBook(consultant), fetchPrepHistory(consultant)])
+      .then(([b, h]) => {
+        if (cancelled) return;
+        setBook(b);
+        setHistory(h);
+      })
       .catch((e) => { if (!cancelled) setError(e?.message || String(e)); });
     return () => { cancelled = true; };
   }, [consultant]);
 
-  const todayIso = new Date().toISOString().slice(0, 10);
+  // Reset paging whenever the visible set changes out from under it.
+  useEffect(() => { setLimit(PAGE_SIZE); }, [tab, search]);
 
-  const rows = useMemo(() => {
+  const todayIso = localIsoDate();
+  const ownBook = isOwnBook(consultant, currentUser?.email);
+
+  const accountRows = useMemo(() => {
     if (!book) return [];
     return book
       .map((snap) => ({ snap, flags: computeFlags(snap, todayIso) }))
-      .sort((a, b) => b.flags.length - a.flags.length || (a.snap.accountName ?? '').localeCompare(b.snap.accountName ?? ''));
+      .sort((a, b) =>
+        b.flags.length - a.flags.length ||
+        (a.snap.accountName ?? '').localeCompare(b.snap.accountName ?? ''));
   }, [book, todayIso]);
 
-  const switchConsultant = () => {
-    localStorage.removeItem(CONSULTANT_KEY);
-    navigate('/call-prep');
-  };
+  const todayRows = useMemo(
+    () => (history ?? []).filter((snap) => snap.snapshotDate === todayIso),
+    [history, todayIso]
+  );
+  const pastRows = useMemo(
+    () => (history ?? []).filter((snap) => snap.snapshotDate < todayIso),
+    [history, todayIso]
+  );
 
-  if (error) return <div style={s.wrap}><div style={s.error}>Couldn’t load book: {error}</div></div>;
-  if (!book) return <div style={s.wrap}><div style={s.note}>Loading {consultant}’s accounts…</div></div>;
+  const term = search.trim().toLowerCase();
+  const matches = (snap) =>
+    !term ||
+    (snap.accountName ?? '').toLowerCase().includes(term) ||
+    (snap.callType ?? '').toLowerCase().includes(term) ||
+    (snap.snapshotDate ?? '').includes(term);
+
+  const active = tab === 'accounts'
+    ? accountRows.filter((r) => matches(r.snap))
+    : (tab === 'today' ? todayRows : pastRows).filter(matches);
+
+  const shown = active.slice(0, limit);
+
+  if (error) {
+    return (
+      <div style={s.wrap}>
+        <div style={s.error}>
+          {/BQ 403/.test(error)
+            ? 'You don’t have access to the call_prep dataset yet. Ask Nic for the BigQuery grant.'
+            : `Couldn’t load this book: ${error}`}
+        </div>
+      </div>
+    );
+  }
+  if (!book || !history) {
+    return <div style={s.wrap}><div style={s.note}>Loading {consultant}’s book…</div></div>;
+  }
+
+  const counts = { today: todayRows.length, past: pastRows.length, accounts: accountRows.length };
+  const needsAttention = accountRows.filter((r) => r.flags.length > 0).length;
 
   return (
     <div style={s.wrap}>
       <div style={s.head}>
-        <h1 style={s.title}>{consultant} — {book.length} account{book.length === 1 ? '' : 's'}</h1>
-        <span style={s.switchLink} onClick={switchConsultant}>switch consultant</span>
+        <div>
+          <div style={s.kicker}>Call prep</div>
+          <h1 style={s.title}>{consultant}</h1>
+        </div>
+        <Link to="/call-prep" style={s.switchLink}>All consultants</Link>
       </div>
-      {!book.length && <div style={s.note}>No snapshots for {consultant} yet.</div>}
-      {book.length > 0 && (
-        <table style={s.table}>
-          <thead>
-            <tr>
-              <th style={s.th}>Account</th>
-              <th style={s.th}>Sync</th>
-              <th style={s.th}>Open cases</th>
-              <th style={s.th}>Last session</th>
-              <th style={s.th}>Last snapshot</th>
-              <th style={s.th}>Attention</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(({ snap, flags }) => (
-              <tr
-                key={snap.accountRecordId}
-                style={s.rowClickable}
-                onClick={() => navigate(`/call-prep/account/${encodeURIComponent(snap.accountRecordId)}`)}
-              >
-                <td style={{ ...s.td, fontWeight: 600 }}>{snap.accountName}</td>
-                <td style={s.td}>{snap.syncStatus ?? '—'}</td>
-                <td style={s.td}>{snap.casesOpenCount}</td>
-                <td style={s.td}>{snap.ttLastSessionDate ?? '—'}</td>
-                <td style={s.td}>{snap.snapshotDate}</td>
-                <td style={s.td}>
-                  {flags.length
-                    ? flags.map((f) => <span key={f} style={s.flag}>{f}</span>)
-                    : <span style={s.ok}>ok</span>}
-                </td>
+
+      <WeekStrip accounts={book} consultant={consultant} ownBook={ownBook} preps={history} />
+
+      {needsAttention > 0 && (
+        <p style={s.attention}>
+          {needsAttention} of {accountRows.length} accounts need attention
+        </p>
+      )}
+
+      <div style={s.tabs}>
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            aria-pressed={tab === t.id}
+            style={{ ...s.tab, ...(tab === t.id ? s.tabActive : null) }}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label} ({counts[t.id]})
+          </button>
+        ))}
+      </div>
+
+      <div style={s.searchRow}>
+        <label htmlFor="prep-search" style={s.label}>Search</label>
+        <input
+          id="prep-search"
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={s.input}
+        />
+      </div>
+
+      {/* Filtering and tab switches change the row count silently on screen;
+          this is the only announcement a screen-reader user gets. */}
+      <p style={s.srOnly} role="status" aria-live="polite">
+        {active.length} {active.length === 1 ? 'row' : 'rows'} in{' '}
+        {TABS.find((t) => t.id === tab).label.toLowerCase()}
+      </p>
+
+      {!active.length ? (
+        <div style={s.note}>
+          {term ? (
+            <>
+              Nothing matches “{search.trim()}” in {TABS.find((t) => t.id === tab).label.toLowerCase()}.
+              <button type="button" style={s.clear} onClick={() => setSearch('')}>Clear search</button>
+            </>
+          ) : tab === 'today' ? (
+            `No preps written for ${consultant} today.`
+          ) : tab === 'past' ? (
+            'No earlier preps.'
+          ) : (
+            `No snapshots for ${consultant} yet.`
+          )}
+        </div>
+      ) : (
+        <>
+          <table style={s.table} aria-label={TABS.find((t) => t.id === tab).label}>
+            <thead>
+              <tr>
+                {tab === 'past' && <th scope="col" style={s.th}>Date</th>}
+                <th scope="col" style={s.th}>Account</th>
+                {tab !== 'accounts' && <th scope="col" style={s.th}>Call type</th>}
+                <th scope="col" style={s.th}>Sync</th>
+                <th scope="col" style={{ ...s.th, ...s.thNum }}>Open cases</th>
+                {tab === 'accounts' && <th scope="col" style={s.th}>Last session</th>}
+                {tab === 'accounts' && <th scope="col" style={s.th}>Last snapshot</th>}
+                <th scope="col" style={s.th}>Attention</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {shown.map((row) => {
+                const snap = tab === 'accounts' ? row.snap : row;
+                const flags = tab === 'accounts' ? row.flags : computeFlags(snap, todayIso);
+                return (
+                  <tr
+                    key={tab === 'accounts' ? snap.accountRecordId : `${snap.accountRecordId}-${snap.snapshotDate}`}
+                    style={s.rowClickable}
+                    onClick={() => navigate(`/call-prep/account/${encodeURIComponent(snap.accountRecordId)}`)}
+                  >
+                    {tab === 'past' && <td style={{ ...s.td, ...s.tdDate }}>{snap.snapshotDate}</td>}
+                    <td style={s.td}><AccountCell snap={snap} /></td>
+                    {tab !== 'accounts' && <td style={s.td}>{snap.callType ?? '—'}</td>}
+                    <td style={s.td}>{sentenceCase(snap.syncStatus)}</td>
+                    <td style={{ ...s.td, ...s.tdNum }}>{snap.casesOpenCount}</td>
+                    {tab === 'accounts' && <td style={s.td}>{snap.ttLastSessionDate ?? '—'}</td>}
+                    {tab === 'accounts' && <td style={s.td}>{snap.snapshotDate}</td>}
+                    <td style={s.td}><Flags flags={flags} /></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          {(shown.length < active.length
+            || (tab === 'past' && history.length >= PREP_HISTORY_LIMIT)) && (
+            <div style={s.more}>
+              {shown.length < active.length && (
+                <button type="button" style={s.moreBtn} onClick={() => setLimit((n) => n + PAGE_SIZE)}>
+                  Show {Math.min(PAGE_SIZE, active.length - shown.length)} more
+                </button>
+              )}
+              <span style={s.count}>
+                Showing {shown.length} of {active.length}
+                {history.length >= PREP_HISTORY_LIMIT && tab === 'past'
+                  ? ` · only the latest ${PREP_HISTORY_LIMIT} preps are loaded`
+                  : ''}
+              </span>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/builder/tests/unit/callPrep.test.js
+++ b/builder/tests/unit/callPrep.test.js
@@ -1,9 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import {
   CALL_PREP_TABLE,
+  BRIEF_CONTENT_TABLE,
   TIME_TRACKING_TABLE,
   CASES_TABLE,
   ACCOUNTS_TABLE,
+  OPPORTUNITY_FIT_TABLE,
+  ACTIVITY_TABLE,
+  buildAccountOpportunityFitSql,
+  buildAccountActivitiesSql,
+  normalizeActivityRow,
+  stripHtml,
+  toWebsiteUrl,
+  latestFitByMotion,
   buildConsultantsSql,
   buildBookSql,
   buildAccountSnapshotsSql,
@@ -41,12 +50,51 @@ describe('buildAccountSnapshotsSql', () => {
   it('filters by record id, newest first', () => {
     const sql = buildAccountSnapshotsSql('141376');
     expect(sql).toContain('account_record_id = 141376');
-    expect(sql).toMatch(/ORDER BY snapshot_date DESC/);
+    expect(sql).toMatch(/ORDER BY s\.snapshot_date DESC/);
+  });
+
+  it('left joins the written brief so preps without one still return', () => {
+    const sql = buildAccountSnapshotsSql('141376');
+    expect(sql).toContain(BRIEF_CONTENT_TABLE);
+    expect(sql).toMatch(/LEFT JOIN/);
+    expect(sql).toMatch(/b\.top_3/);
+    expect(sql).toMatch(/b\.why_today/);
+  });
+
+  // Both tables are append-only with no key: a routine that runs twice in a day
+  // leaves two rows for one (account, date). Without both QUALIFYs that shows
+  // the same date twice in the picker and fans the join out.
+  it('keeps one row per snapshot date on both sides of the join', () => {
+    const sql = buildAccountSnapshotsSql('141376');
+    expect(sql).toMatch(/PARTITION BY account_record_id, snapshot_date ORDER BY created_at DESC/);
+    expect(sql).toMatch(/PARTITION BY s\.snapshot_date ORDER BY s\.created_at DESC/);
   });
 
   it('rejects non-integer record ids', () => {
     expect(() => buildAccountSnapshotsSql('141376; DROP TABLE x')).toThrow();
     expect(() => buildAccountSnapshotsSql('abc')).toThrow();
+  });
+});
+
+describe('toWebsiteUrl', () => {
+  // Every historical brief_content row stores a bare host, not a URL.
+  it('gives a bare domain a scheme', () => {
+    expect(toWebsiteUrl('primodoors.com')).toBe('https://primodoors.com');
+    expect(toWebsiteUrl('arrowconservation.com/about')).toBe('https://arrowconservation.com/about');
+  });
+
+  it('leaves an absolute URL alone', () => {
+    expect(toWebsiteUrl('http://example.com')).toBe('http://example.com');
+    expect(toWebsiteUrl('https://example.com/x')).toBe('https://example.com/x');
+  });
+
+  it('refuses anything that is not a plain host', () => {
+    expect(toWebsiteUrl('javascript:alert(1)')).toBeNull();
+    expect(toWebsiteUrl('data:text/html,<script>')).toBeNull();
+    expect(toWebsiteUrl('not a domain')).toBeNull();
+    expect(toWebsiteUrl('localhost')).toBeNull();
+    expect(toWebsiteUrl('')).toBeNull();
+    expect(toWebsiteUrl(null)).toBeNull();
   });
 });
 
@@ -62,6 +110,104 @@ describe('buildAccountSessionsSql', () => {
   it('rejects non-integer record ids', () => {
     expect(() => buildAccountSessionsSql('1; DROP TABLE x')).toThrow();
     expect(() => buildAccountSessionsSql('abc')).toThrow();
+  });
+});
+
+describe('buildAccountOpportunityFitSql', () => {
+  it('reads every assessment for the account, newest first', () => {
+    const sql = buildAccountOpportunityFitSql('141376');
+    expect(sql).toContain(OPPORTUNITY_FIT_TABLE);
+    expect(sql).toContain('account_record_id = 141376');
+    expect(sql).toMatch(/ORDER BY assessed_date DESC/);
+  });
+
+  it('rejects non-integer record ids', () => {
+    expect(() => buildAccountOpportunityFitSql('1; DROP TABLE x')).toThrow();
+  });
+});
+
+describe('buildAccountActivitiesSql', () => {
+  it('queries Activity by account, newest first, excluding deleted', () => {
+    const sql = buildAccountActivitiesSql('141376');
+    expect(sql).toContain(ACTIVITY_TABLE);
+    expect(sql).toContain('MethodCompanyAccountRecordID = 141376');
+    expect(sql).toMatch(/IsDeleted = FALSE/);
+    expect(sql).toMatch(/LIMIT 10/);
+  });
+
+  // mockBq's batched cross-account route matches on `AS activity_date`; if this
+  // query ever uses that alias again, mock mode silently serves the wrong rows.
+  it('does not alias its date column activity_date', () => {
+    expect(buildAccountActivitiesSql('141376')).not.toMatch(/AS activity_date/);
+  });
+
+  it('rejects non-integer record ids and limits', () => {
+    expect(() => buildAccountActivitiesSql('abc')).toThrow();
+    expect(() => buildAccountActivitiesSql('141376', '10; DROP TABLE x')).toThrow();
+  });
+});
+
+describe('stripHtml', () => {
+  it('reduces CRM rich text to plain prose', () => {
+    expect(stripHtml('<p>Called Tom &amp; left a vm&nbsp;today</p>')).toBe('Called Tom & left a vm today');
+  });
+
+  it('turns block ends into line breaks', () => {
+    expect(stripHtml('<p>One</p><p>Two</p>')).toBe('One\nTwo');
+  });
+
+  it('drops script bodies rather than inlining them', () => {
+    expect(stripHtml('<script>alert(1)</script>hello')).toBe('hello');
+  });
+
+  it('returns null for empty or markup-only input', () => {
+    expect(stripHtml('')).toBeNull();
+    expect(stripHtml('<p></p>')).toBeNull();
+    expect(stripHtml(null)).toBeNull();
+  });
+});
+
+describe('normalizeActivityRow', () => {
+  it('casts an Activity row to a typed activity', () => {
+    expect(normalizeActivityRow({
+      RecordID: '1749823', occurred_on: '2026-08-04', ActivityType: 'Demo',
+      ActivityStatus: 'Completed', AssignedToRecordID: '455', Comments: '<p>Walked the estimate flow.</p>',
+    })).toEqual({
+      recordId: 1749823, date: '2026-08-04', type: 'Demo', status: 'Completed',
+      agentId: 455, notes: 'Walked the estimate flow.',
+    });
+  });
+});
+
+describe('latestFitByMotion', () => {
+  const row = (motion, assessedDate, fit) => ({ motion, assessedDate, fit, signals: [] });
+
+  it('keeps the newest assessment per motion in reading order', () => {
+    const out = latestFitByMotion([
+      row('ppu', '2026-08-01', 'current'),
+      row('method_pay', '2026-08-10', 'strong'),
+      row('method_pay', '2026-07-01', 'none'),
+    ], '2026-08-10');
+    expect(out.map((r) => r.motion)).toEqual(['method_pay', 'ppu']);
+    expect(out[0].fit).toBe('strong');
+  });
+
+  it('ignores assessments made after the prep being read', () => {
+    const out = latestFitByMotion([
+      row('dep', '2026-08-10', 'strong'),
+      row('dep', '2026-07-01', 'none'),
+    ], '2026-07-15');
+    expect(out).toHaveLength(1);
+    expect(out[0].fit).toBe('none');
+  });
+
+  it('still returns motions outside the known set', () => {
+    const out = latestFitByMotion([row('partner_referral', '2026-08-10', 'strong')], '2026-08-10');
+    expect(out.map((r) => r.motion)).toEqual(['partner_referral']);
+  });
+
+  it('tolerates no rows', () => {
+    expect(latestFitByMotion(null, '2026-08-10')).toEqual([]);
   });
 });
 

--- a/builder/tests/unit/googleCalendar.test.js
+++ b/builder/tests/unit/googleCalendar.test.js
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { _setBqToken } from '../../src/lib/bigquery.js';
+import {
+  accountTokens,
+  addDays,
+  fetchCalendarEvents,
+  formatEventTime,
+  matchEvent,
+  matchEvents,
+  normalizeEvent,
+  startOfWeek,
+  weekDays,
+} from '../../src/lib/googleCalendar.js';
+import {
+  CalendarAccessError,
+  CalendarScopeError,
+  fetchCalendarList,
+  matchCalendarForConsultant,
+} from '../../src/lib/googleCalendar.js';
+import { buildPrepHistorySql, PREP_HISTORY_LIMIT, CALL_PREP_TABLE, fetchPrepHistory } from '../../src/lib/callPrep.js';
+
+const account = (id, name) => ({ accountRecordId: id, accountName: name });
+
+const ACCOUNTS = [
+  account(1, 'Northwind Traders'),
+  account(2, 'Harborview Dental Group'),
+  account(3, 'Cedarline Millwork'),
+  account(4, 'Pike & Powell Supply'),
+];
+
+const event = (over = {}) => ({ title: '', attendees: [], ...over });
+
+describe('normalizeEvent', () => {
+  it('buckets a timed event into its local day', () => {
+    const e = normalizeEvent({
+      id: 'a',
+      summary: 'Northwind call',
+      start: { dateTime: '2026-08-10T09:30:00' },
+      attendees: [{ email: 'Dana@Northwind.com' }],
+    });
+    expect(e.day).toBe('2026-08-10');
+    expect(e.allDay).toBe(false);
+    expect(e.attendees).toEqual(['dana@northwind.com']);
+  });
+
+  it('treats a date-only event as all day without shifting the day', () => {
+    const e = normalizeEvent({ id: 'b', summary: 'PTO', start: { date: '2026-08-11' } });
+    expect(e.allDay).toBe(true);
+    expect(e.day).toBe('2026-08-11');
+    expect(formatEventTime(e)).toBe('All day');
+  });
+
+  it('flags an event the signed-in user declined', () => {
+    const e = normalizeEvent({
+      id: 'c',
+      summary: 'Standup',
+      start: { dateTime: '2026-08-10T09:00:00' },
+      attendees: [
+        { email: 'me@method.me', self: true, responseStatus: 'declined' },
+        { email: 'other@method.me', responseStatus: 'accepted' },
+      ],
+    });
+    expect(e.declined).toBe(true);
+  });
+
+  it('survives an event with no title or attendees', () => {
+    const e = normalizeEvent({ id: 'd', start: { dateTime: '2026-08-10T09:00:00' } });
+    expect(e.title).toBe('(no title)');
+    expect(e.attendees).toEqual([]);
+  });
+});
+
+describe('weekDays / startOfWeek', () => {
+  it('starts the week on Monday regardless of which day is passed', () => {
+    // 2026-08-13 is a Thursday; 2026-08-16 the Sunday after.
+    expect(weekDays(startOfWeek(new Date(2026, 7, 13)), 5))
+      .toEqual(['2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13', '2026-08-14']);
+    expect(weekDays(startOfWeek(new Date(2026, 7, 16)), 5)[0]).toBe('2026-08-10');
+  });
+
+  it('steps whole weeks without drifting across a DST boundary', () => {
+    // 2026-11-01 is the US DST fallback; adding 7 days must stay on Monday.
+    const monday = startOfWeek(new Date(2026, 9, 26));
+    expect(addDays(monday, 7).getDay()).toBe(1);
+  });
+});
+
+describe('accountTokens', () => {
+  it('drops filler words and keeps distinctive ones, longest first', () => {
+    expect(accountTokens('Pike & Powell Supply Inc')).toEqual(['powell', 'pike']);
+    expect(accountTokens('Bright Harbor Logistics')).toEqual(['logistics', 'bright', 'harbor']);
+  });
+
+  it('returns nothing for a name that is all filler', () => {
+    expect(accountTokens('The Company LLC')).toEqual([]);
+  });
+});
+
+describe('matchEvent', () => {
+  it('matches the full account name in a title', () => {
+    const m = matchEvent(event({ title: 'Northwind Traders — PPU session' }), ACCOUNTS);
+    expect(m.account.accountRecordId).toBe(1);
+    expect(m.via).toBe('title');
+  });
+
+  it('matches on one distinctive word when the full name is absent', () => {
+    const m = matchEvent(event({ title: 'Harborview check-in' }), ACCOUNTS);
+    expect(m.account.accountRecordId).toBe(2);
+    expect(m.via).toBe('title');
+  });
+
+  it('falls back to the attendee domain when the title says nothing', () => {
+    const m = matchEvent(
+      event({ title: 'Quarterly workflow review', attendees: ['ap@cedarlinemillwork.com'] }),
+      ACCOUNTS
+    );
+    expect(m.account.accountRecordId).toBe(3);
+    expect(m.via).toBe('attendee');
+  });
+
+  it('prefers a title match over an attendee match', () => {
+    const m = matchEvent(
+      event({ title: 'Northwind Traders sync', attendees: ['ap@cedarlinemillwork.com'] }),
+      ACCOUNTS
+    );
+    expect(m.account.accountRecordId).toBe(1);
+    expect(m.via).toBe('title');
+  });
+
+  it('ignores mailbox providers and our own domain', () => {
+    expect(matchEvent(event({ title: '1:1', attendees: ['someone@gmail.com'] }), ACCOUNTS)).toBeNull();
+    expect(matchEvent(event({ title: 'PS standup', attendees: ['team@method.me'] }), ACCOUNTS)).toBeNull();
+  });
+
+  it('does not match on a short or filler word', () => {
+    // "Supply" is a stopword and "Pike" is under the 5-char domain/title bar,
+    // so a generic supply meeting must not land on Pike & Powell.
+    expect(matchEvent(event({ title: 'Supply chain sync' }), ACCOUNTS)).toBeNull();
+  });
+
+  it('returns null for an untitled event with no attendees', () => {
+    expect(matchEvent(event({ title: '' }), ACCOUNTS)).toBeNull();
+  });
+
+  it('returns null when the book is empty', () => {
+    expect(matchEvent(event({ title: 'Northwind Traders' }), [])).toBeNull();
+  });
+});
+
+describe('matchEvents', () => {
+  it('attaches a match to every event, null where none was found', () => {
+    const out = matchEvents(
+      [event({ title: 'Northwind Traders' }), event({ title: 'Dentist' })],
+      ACCOUNTS
+    );
+    expect(out[0].match.account.accountRecordId).toBe(1);
+    expect(out[1].match).toBeNull();
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe('fetchCalendarEvents', () => {
+  const ok = (items) => async () => ({ ok: true, status: 200, json: async () => ({ items }) });
+
+  beforeEach(() => _setBqToken('test-token'));
+
+  it('raises CalendarScopeError before any request when there is no token', async () => {
+    _setBqToken(null);
+    let called = false;
+    const fetchImpl = async () => { called = true; return ok([])(); };
+    await expect(fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }))
+      .rejects.toBeInstanceOf(CalendarScopeError);
+    expect(called).toBe(false);
+  });
+
+  it('requests an expanded, time-ordered window and normalizes the result', async () => {
+    let seen = null;
+    const fetchImpl = async (url) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => ({ items: [{ id: 'x', summary: 'Call', start: { dateTime: '2026-08-10T09:00:00' } }] }) };
+    };
+    const events = await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl });
+    expect(seen).toContain('singleEvents=true');
+    expect(seen).toContain('orderBy=startTime');
+    expect(events[0].day).toBe('2026-08-10');
+  });
+
+  it('raises CalendarScopeError on 403 so the UI can offer re-consent', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 403, json: async () => ({}) });
+    await expect(fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }))
+      .rejects.toBeInstanceOf(CalendarScopeError);
+  });
+
+  it('does not offer re-consent when the Calendar API is disabled on the project', async () => {
+    // Same 403, different cause — clicking Connect can never fix this one.
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { message: 'Google Calendar API has not been used in project 546732685010 before or it is disabled.' } }),
+    });
+    const err = await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }).catch((e) => e);
+    expect(err).not.toBeInstanceOf(CalendarScopeError);
+    expect(err.message).toContain('has not been used in project');
+  });
+
+  it('raises a plain error on other failures', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 500, json: async () => ({}) });
+    const err = await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }).catch((e) => e);
+    expect(err).not.toBeInstanceOf(CalendarScopeError);
+    expect(err.message).toContain('500');
+  });
+
+  it('returns an empty list when the calendar has no events', async () => {
+    expect(await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl: ok([]) })).toEqual([]);
+  });
+});
+
+describe('matchCalendarForConsultant', () => {
+  const CALENDARS = [
+    { id: 'b.saltzman@method.me', summary: 'Brandon Saltzman', primary: true },
+    { id: 's.zarei@method.me', summary: 'Sherry Zarei', primary: false },
+    { id: 'ps-team@method.me', summary: 'PS Team Events', primary: false },
+  ];
+
+  it('matches a full name against the calendar title', () => {
+    expect(matchCalendarForConsultant('Sherry Zarei', CALENDARS).id).toBe('s.zarei@method.me');
+  });
+
+  it('matches the abbreviated convention the snapshots feed also writes', () => {
+    expect(matchCalendarForConsultant('S. Zarei', CALENDARS).id).toBe('s.zarei@method.me');
+  });
+
+  it('falls back to the address when the calendar has no display name', () => {
+    const bare = [{ id: 'v.gobin@method.me', summary: '', primary: false }];
+    expect(matchCalendarForConsultant('Vinesh Gobin', bare).id).toBe('v.gobin@method.me');
+  });
+
+  it('never returns the signed-in user’s own calendar', () => {
+    expect(matchCalendarForConsultant('Brandon Saltzman', CALENDARS)).toBeNull();
+  });
+
+  it('returns null when no subscribed calendar belongs to them', () => {
+    expect(matchCalendarForConsultant('Vinesh Gobin', CALENDARS)).toBeNull();
+  });
+
+  it('returns null for a name with no first/last structure', () => {
+    expect(matchCalendarForConsultant('Sherry', CALENDARS)).toBeNull();
+    expect(matchCalendarForConsultant('', CALENDARS)).toBeNull();
+  });
+
+  it('does not match a different person sharing a last name initial', () => {
+    // "Sam Zabinski" shares neither the last name nor the address.
+    expect(matchCalendarForConsultant('Sam Zabinski', CALENDARS)).toBeNull();
+  });
+});
+
+describe('fetchCalendarList', () => {
+  beforeEach(() => _setBqToken('test-token'));
+
+  it('asks only for calendars this user can read', async () => {
+    let seen = null;
+    const fetchImpl = async (url) => {
+      seen = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [{ id: 'a@method.me', summary: 'A', primary: true }] }),
+      };
+    };
+    const list = await fetchCalendarList({ fetchImpl });
+    expect(seen).toContain('minAccessRole=reader');
+    expect(list).toEqual([{ id: 'a@method.me', summary: 'A', primary: true }]);
+  });
+});
+
+describe('reading a teammate’s calendar', () => {
+  beforeEach(() => _setBqToken('test-token'));
+
+  it('requests the named calendar rather than primary', async () => {
+    let seen = null;
+    const fetchImpl = async (url) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => ({ items: [] }) };
+    };
+    await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl, calendarId: 's.zarei@method.me' });
+    expect(seen).toContain(encodeURIComponent('s.zarei@method.me'));
+  });
+
+  it('reports a calendar it cannot read as an access problem, not a scope one', async () => {
+    // Re-consenting would not help here, so the Connect button must not appear.
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { message: 'Not Found' } }),
+    });
+    const err = await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl, calendarId: 'x@method.me' })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(CalendarAccessError);
+    expect(err).not.toBeInstanceOf(CalendarScopeError);
+  });
+
+  it('resolves an unrecognizable 403 by whose calendar it is', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 403, json: async () => ({}) });
+    // Own calendar: most likely the token, so offer re-consent.
+    await expect(fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }))
+      .rejects.toBeInstanceOf(CalendarScopeError);
+    // Someone else's: most likely sharing, which re-consenting cannot fix.
+    const err = await fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl, calendarId: 's.zarei@method.me' })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(CalendarAccessError);
+  });
+
+  it('still treats a genuine scope failure as re-consentable', async () => {
+    const fetchImpl = async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { message: 'Request had insufficient authentication scopes.' } }),
+    });
+    await expect(fetchCalendarEvents('2026-08-10', '2026-08-14', { fetchImpl }))
+      .rejects.toBeInstanceOf(CalendarScopeError);
+  });
+});
+
+describe('buildPrepHistorySql', () => {
+  it('reads every prep for one consultant, newest first, under a cap', () => {
+    const sql = buildPrepHistorySql('Brandon Saltzman');
+    expect(sql).toContain(CALL_PREP_TABLE);
+    expect(sql).toContain("consultant = 'Brandon Saltzman'");
+    expect(sql).toContain('ORDER BY snapshot_date DESC');
+    expect(sql).toContain(`LIMIT ${PREP_HISTORY_LIMIT}`);
+    // Unlike the book query it must NOT dedupe to the latest row per account.
+    expect(sql).not.toContain('QUALIFY');
+  });
+
+  it('escapes a quote in the consultant name', () => {
+    expect(buildPrepHistorySql("D'Angelo Reyes")).toContain("consultant = 'D\\'Angelo Reyes'");
+  });
+
+  it('rejects a non-numeric limit rather than interpolating it', () => {
+    expect(() => buildPrepHistorySql('Someone', '5; DROP TABLE x')).toThrow();
+  });
+
+  it('normalizes rows through the shared snapshot normalizer', async () => {
+    const query = async () => ({
+      rows: [{ account_record_id: '900101', account_name: 'Northwind Traders', snapshot_date: '2026-08-10', cases_open_count: '2' }],
+    });
+    const [row] = await fetchPrepHistory('Brandon Saltzman', { query });
+    expect(row.accountRecordId).toBe(900101);
+    expect(row.casesOpenCount).toBe(2);
+  });
+});

--- a/builder/tests/unit/mockBq.test.js
+++ b/builder/tests/unit/mockBq.test.js
@@ -15,6 +15,12 @@ import {
   buildAccountSessionsSql,
   buildAccountCasesSql,
   buildAccountOverviewSql,
+  buildAccountOpportunityFitSql,
+  buildAccountActivitiesSql,
+  normalizeOpportunityFitRow,
+  normalizeActivityRow,
+  latestFitByMotion,
+  MOTION_ORDER,
   normalizeSnapshotRow,
   normalizeSessionRow,
   normalizeCaseRow,
@@ -159,6 +165,28 @@ describe('mock router — call-prep book and account detail', () => {
     const session = normalizeSessionRow(rows[0]);
     expect(typeof session.durationHours).toBe('number');
     expect(typeof session.notes).toBe('string');
+  });
+
+  it('returns every assessed motion for an account', () => {
+    const fit = rowsFor(buildAccountOpportunityFitSql(NORTHWIND)).map(normalizeOpportunityFitRow);
+    expect(fit.length).toBeGreaterThan(0);
+    expect(new Set(fit.map((f) => f.motion))).toEqual(new Set(MOTION_ORDER));
+    expect(fit.some((f) => f.signals.length > 0)).toBe(true);
+    expect(fit.some((f) => f.caveats)).toBe(true);
+    const ordered = latestFitByMotion(fit, TODAY);
+    expect(ordered.map((f) => f.motion)).toEqual(MOTION_ORDER);
+  });
+
+  it('returns activities newest first with the markup stripped', () => {
+    const acts = rowsFor(buildAccountActivitiesSql(NORTHWIND)).map(normalizeActivityRow);
+    expect(acts.length).toBeGreaterThan(0);
+    expect(acts.length).toBeLessThanOrEqual(10);
+    const dates = acts.map((a) => a.date);
+    expect([...dates].sort().reverse()).toEqual(dates);
+    for (const a of acts) {
+      expect(a).not.toHaveProperty('_account');
+      expect(a.notes).not.toMatch(/[<>]|&nbsp;/);
+    }
   });
 
   it('returns both open and closed cases', () => {

--- a/docs/ui-audit-call-prep.md
+++ b/docs/ui-audit-call-prep.md
@@ -1,0 +1,333 @@
+# Call Prep — UI audit ledger
+
+**Scope:** `#/call-prep`, `#/call-prep/:consultant`, the week strip,
+`#/call-prep/account/:recordId`, and the PS nav entry.
+**Auditor:** `.claude/skills/call-prep-ui-audit/SKILL.md`
+
+This is a ledger, not a one-off report. Finding ids are stable across runs — a
+later sweep marks an id fixed rather than renumbering.
+
+---
+
+## Status
+
+| Id | Finding | Severity | Status | Run |
+|---|---|---|---|---|
+| CP-01 | Week strip days have no structure in the accessibility tree | critical | ✅ fixed | 2026-08-10 |
+| CP-02 | An empty day renders as `—` | major | ✅ fixed | 2026-08-10 |
+| CP-03 | An empty week looks like a broken calendar | major | ✅ fixed | 2026-08-10 |
+| CP-04 | "Loading **your** calendar" shown on a teammate's book | major | ✅ fixed | 2026-08-10 |
+| CP-05 | Search and tab filtering change row counts silently | major | ✅ fixed | 2026-08-10 |
+| CP-06 | Calendar narrates *how* it matched an account | minor | ✅ fixed | 2026-08-10 |
+| CP-07 | Strip footer reads as system vocabulary | minor | ✅ fixed | 2026-08-10 |
+| CP-08 | Raw lowercase `sync_status` from BigQuery reaches the screen | minor | ✅ fixed | 2026-08-10 |
+| CP-09 | Book page `<h1>` is a bare name with no context | minor | ✅ fixed | 2026-08-10 |
+| CP-10 | **Today's calls don't show which ones have no prep written** | major | ✅ fixed | 2026-08-10 |
+| CP-11 | **Account trouble isn't visible next to the call** | major | ✅ fixed | 2026-08-10 |
+| CP-12 | **No attention count above the fold** | major | ✅ fixed | 2026-08-10 |
+| CP-13 | Account brief has eight sections and zero `<h2>`s | critical | ✅ fixed | 2026-08-10 (run 2) |
+| CP-14 | Toolbar navigation built from `<button onClick>` | major | ✅ fixed | 2026-08-10 (run 2) |
+| CP-15 | Entry animation ignores `prefers-reduced-motion` | major | ✅ fixed | 2026-08-10 (run 2) |
+| CP-16 | Anchor offset is a fixed 110px inside a zoomable container | minor | ✅ fixed | 2026-08-10 (run 2) |
+| CP-17 | "click to read notes →" repeated on every expandable row | major | ✅ fixed | 2026-08-10 (run 2) |
+| CP-18 | Details section repeats 12 of its 14 fields from elsewhere | major | ✅ fixed | 2026-08-10 (run 2) |
+| CP-19 | Jump nav never shows which section you're in | major | ✅ fixed | 2026-08-10 (run 2) |
+| CP-20 | Fit badge renders the raw lowercase enum | minor | ✅ fixed | 2026-08-10 (run 2) |
+| CP-21 | Activities capped at 10 with no disclosure | minor | ✅ fixed | 2026-08-10 (run 2) |
+| CP-22 | Case badges set at 9.5px | minor | ✅ fixed | 2026-08-10 (run 2) |
+| CP-23 | Snapshot-date select is the only unlabelled control | minor | ✅ fixed | 2026-08-10 (run 2) |
+| CP-24 | "source document" link doesn't read as a link | minor | ✅ fixed | 2026-08-10 (run 2) |
+
+---
+
+## Run 2 — `CallPrepAccount.jsx`, second pass
+
+Run 1 called this screen "the strongest in the area" on the strength of its
+accessibility *attributes* — `aria-label`s, an `sr-only` caption, a documented
+contrast palette. That was an audit of the markup's good intentions, not of the
+interface. Re-read as a screen, it has one critical fault and five majors.
+
+Two things run 1 worried about turned out fine and are recorded so a later run
+doesn't re-litigate them: **Fraunces is loaded properly** (`builder/index.html:7`
+requests all three families), and **activities are capped in SQL**
+(`ACTIVITY_LIMIT = 10`) rather than rendering unbounded.
+
+### CP-13 · critical · `CallPrepAccount.jsx` (8 sites)
+
+Every section title — Top 3, Why today, Opportunity fit, DEP signals, Time
+tracking, Cases, Recent activities, Details — plus all three rail-card titles was
+a `<div style={s.bodyLabel}>`. The document had exactly one heading (`<h1>`, the
+account name) and nothing below it.
+
+Heading navigation is the primary way screen-reader users move through a long
+document. On the longest screen in the product it did not exist. This is the
+finding that most directly contradicts run 1's verdict.
+
+Fix: `<h2>` throughout, with `margin: '0 0 14px'` on `bodyLabel` so the visual
+result is byte-identical.
+
+### CP-14 · major · `CallPrepAccount.jsx` toolbar
+
+Current: `<button onClick={() => navigate('/call-prep/…')}>← Brandon's book</button>`
+
+Both crumbs navigate but are buttons, so middle-click, cmd-click, "open in new
+tab" and "copy link address" all fail, and nothing appears in the status bar on
+hover. `docs/ui-audit-2026-08-05.md` fixed this exact pattern on the tracker
+(C4, "9 navigate-only buttons converted to links"); it came back here.
+
+Fix: `<Link to=…>`.
+
+### CP-15 · major · `CallPrepAccount.jsx` CSS block
+
+`.cp-rise` animates the kicker, title and identity block on every load, with
+staggered 40ms/90ms delays and a `scroll-behavior: smooth` jump nav. Neither
+honours `prefers-reduced-motion`, which for a vestibular-sensitive reader is the
+difference between usable and not.
+
+Fix: a `@media (prefers-reduced-motion: reduce)` block disabling the animation,
+the caret transition, and smooth scrolling.
+
+### CP-17 · major · `CallPrepAccount.jsx` (2 sites)
+
+Current: `click to read notes →`
+
+Rendered under **every** session and activity that has notes — up to 16 times on
+one screen. Three faults at once: it instructs the reader how to operate the UI
+rather than showing an affordance; it's the same string repeated as visual noise;
+and the arrow points right while the content expands downward.
+
+The row is already a `<button aria-expanded>`, so the accessible behaviour was
+there and only the visual affordance was missing.
+
+Fix: delete the string. Add a `▸` caret that rotates to `▾` when open — the
+standard disclosure affordance, one glyph, correct direction.
+
+### CP-18 · major · `CallPrepAccount.jsx` Details section
+
+The Details grid held 14 fields. **Twelve of them already appear higher on the
+same page**: Signup date and Account age and DEP enrolled in the identity block;
+Time tracked, Sessions and Last session in the stat strip; Open cases, Sync
+status, Sync failures and Parent entity in the Snapshot card; Industry and
+Operating model in the Business context card.
+
+So the section cost a screenful of scrolling to repeat what the reader had
+already passed, and pushed the genuinely unique fields out of sight.
+
+Fix: cut to the two fields nothing else shows — Closed cases (90d) and Contact
+phone. If a 2-item Details section reads thin, the alternative is deleting the
+section and moving both fields into the Snapshot card; flagging rather than
+deciding, since the section order deliberately mirrors the `/call-prep` Google Doc.
+
+### CP-19 · major · `CallPrepAccount.jsx` jump nav
+
+Eight sticky chips that scroll you somewhere and never indicate where you are.
+On a document this long the nav is the map, and the map had no "you are here".
+
+Fix: an `IntersectionObserver` scroll spy highlighting the current chip, with
+`aria-current` so it isn't colour-only. Section list moved into one `SECTIONS`
+constant shared by the nav and the spy, so a section can't appear in one and not
+the other.
+
+### CP-16 · minor · `CallPrepAccount.jsx`
+
+`section { scrollMarginTop: 110 }` is a fixed value, but the sheet renders inside
+`zoom: {zoom/100}`. The sticky nav's own offset is zoom-corrected
+(`TOOLBAR_H / (zoom/100)`); the anchor offset wasn't, so at 150% zoom a jump
+overshot and left a gap above the heading.
+
+Fix: derive it — `navTop + NAV_H` — so both follow zoom together.
+
+### CP-20 · minor · `CallPrepAccount.jsx` fit table
+
+Current: `{row.fit ?? 'unknown'}` → renders `strong`, `moderate`, `current`, `none`
+
+Raw BigQuery enum on screen, and `none` reads as missing data rather than as an
+assessment that the motion doesn't fit.
+
+Replacement: `Strong` / `Moderate` / `Current` / `No fit` / `Unknown`.
+
+### CP-21 · minor · `CallPrepAccount.jsx` activities
+
+`ACTIVITY_LIMIT = 10` is applied in SQL and never mentioned on screen, while the
+sessions list right above it discloses its cap ("Show all 23 sessions"). The repo
+standard is no silent caps.
+
+Fix: `Latest 10 activities.` when the cap is hit.
+
+### CP-22 · minor · `CallPrepAccount.jsx:216`
+
+`caseBadge` set at `fontSize: 9.5`. Below the readable floor, and the smallest
+type in the product.
+
+Fix: 10.5, matching the other badges.
+
+### CP-23 · minor · `CallPrepAccount.jsx` toolbar
+
+The snapshot-date `<select>` carried `aria-label="Snapshot date"` but no visible
+label, sitting beside Width and Zoom which both have visible labels. A bare date
+dropdown gives no clue what changing it does.
+
+Fix: visible `Snapshot` label in the established `controlLabel` style, wired with
+`aria-labelledby`.
+
+### CP-24 · minor · `CallPrepAccount.jsx:242`
+
+`sourceLink` was `MUTE` text with a `RULE`-coloured bottom border — muted grey on
+grey, reading as body text rather than the only outbound link on the page.
+
+Fix: `ACCENT` text with an `ACCENT` border.
+
+---
+
+## Lens 1 — AI slop
+
+The copy here is in much better shape than the project tracker was. The em-dash
+justification pattern that dominated `docs/ui-audit-2026-08-05.md` appears **zero**
+times across these five files. Two findings, both minor.
+
+### CP-06 · minor · `WeekStrip.jsx:237`
+
+Current: `Matched on attendee domain`
+
+Naming the mechanism teaches the reader how the matcher works, which is the
+call-prep flavour of "teaching the data model". What the rep needs is that the
+link is uncertain, not which signal produced it. The reasoning belongs in the
+code comment that already sits above `matchEvent`.
+
+Replacement: `Best guess`
+
+### CP-07 · minor · `WeekStrip.jsx:251-252`
+
+Current: `12 events, 4 matched to an account.`
+
+"Matched to an account" is the matcher's vocabulary, not a consultant's. A rep
+thinks in calls, not matches.
+
+Replacement: `12 events · 4 linked to an account`
+
+---
+
+## Lens 2 — Readability and access
+
+### CP-01 · critical · `WeekStrip.jsx:213-220`
+
+The week is a `display: grid` of `<div>`s. Every day column, its date, and its
+events are visually distinct and structurally identical — a screen-reader user
+gets one flat run of text with no way to tell Tuesday's calls from Wednesday's.
+The visible `Mon Aug 10` heading is a styled `<div>`, invisible to assistive tech
+as a label.
+
+Fix: give each column `role="group"` with an `aria-label` carrying the full date,
+so the day name enters the accessibility tree without changing the visual design
+or inventing a heading level that would break the page's hierarchy.
+
+### CP-02 · major · `WeekStrip.jsx:218`
+
+Current: `—`
+
+An em dash is not an empty state. It reads aloud as "em dash" and carries no
+meaning visually either.
+
+Replacement: `No events` (in the muted style already defined)
+
+### CP-03 · major · `WeekStrip.jsx`
+
+A week with no events at all renders five columns of `—` and no footer, which is
+indistinguishable from a failed load. Loading and empty must be different states.
+
+Fix: when the week has no events, render one line — `Nothing on the calendar this
+week.` — instead of the column grid.
+
+### CP-04 · major · `WeekStrip.jsx:205`
+
+Current: `Loading your calendar…`
+
+Wrong the moment a rep opens a teammate's book, which is now a supported path.
+Every possessive on these screens has to hold in both cases.
+
+Replacement: `Loading the calendar…`
+
+### CP-05 · major · `CallPrep.jsx:132`, `CallPrepBook.jsx`
+
+Both screens filter a table from a search box, and `CallPrepBook` also swaps the
+whole table when a tab changes. The row count changes with no announcement, so a
+screen-reader user has no idea whether typing narrowed anything.
+
+Fix: a polite live region reporting the visible count, updated on every filter or
+tab change.
+
+### CP-08 · minor · `CallPrepBook.jsx:272`
+
+Current: `{snap.syncStatus ?? '—'}`
+
+`normalizeSnapshotRow` lowercases the BigQuery value, so the Sync column renders
+`ok` / `failing`. That's the column's value, not a word anyone would write.
+
+Fix: capitalise for display. Keep the stored value lowercase — comparisons
+elsewhere depend on it.
+
+### CP-09 · minor · `CallPrepBook.jsx:198`
+
+Current: `<h1>{consultant}</h1>`
+
+The page title is a bare person's name. Opened from a bookmark or a shared link,
+nothing on screen says what the page is. `CallPrepAccount` already solves this
+with a mono kicker above the title; this screen should match it.
+
+Fix: add a `Call prep` kicker above the name, reusing the established pattern.
+
+---
+
+## Lens 3 — At a glance
+
+The three findings that actually change how useful this screen is in the ninety
+seconds before a call.
+
+### CP-10 · major — which calls have no prep?
+
+The week strip gives every account-matched event the same green **Prep** button
+whether or not a brief was written for that day. The most actionable fact on the
+screen — *this call has no prep* — is invisible, and the button leads to a stale
+brief from some earlier date without saying so.
+
+Fix: cross-reference each event against the prep history already loaded by
+`CallPrepBook`. An event whose account has a snapshot on that day keeps the green
+**Prep** button. One that doesn't, on today or later, gets a muted **Open**
+button and a `no prep` chip. Past days are left alone — a missing prep on a call
+that already happened is history, not a task.
+
+### CP-11 · major — is this account in trouble right now?
+
+`computeFlags` already derives sync failures, open cases and stale sessions per
+account, and the Accounts tab shows them. The calendar — the thing a rep actually
+looks at before a call — shows none of it, so walking into a call with a failing
+sync is indistinguishable from a routine one.
+
+Fix: surface the account's flags on the event card, capped at two so the card
+stays skimmable, with a `+N` overflow marker.
+
+### CP-12 · major — how much needs attention?
+
+The Accounts tab sorts flagged rows first, which helps only after you've clicked
+into it. There's no count anywhere above the fold.
+
+Fix: a one-line summary above the tabs — `4 of 23 accounts need attention` — and
+nothing when the number is zero, so a clean book stays clean.
+
+---
+
+## What's already good
+
+- **`CallPrepAccount.jsx` has the best accessibility *plumbing*** in the area —
+  contrast tokens carry their measured ratio in a comment, the fit table has an
+  `sr-only` `<caption>` with `scope` on both axes, there's a real
+  `:focus-visible` ring, and the zoom control is `aria-live`. Run 1 over-read
+  that as the screen being sound; run 2 found a critical and five majors it had
+  missed. **Good attributes are not the same as a good screen** — audit what
+  renders, not what's declared.
+- **No em-dash justifications anywhere.** The pattern that produced 20+ findings
+  on the project tracker has not recurred here.
+- **Caps are disclosed, never silent** — "Showing 50 of 214", "only the latest 500
+  preps are loaded", and the hidden-events count on the strip.
+- **Meaning is never carried by colour alone** — flags pair amber with the word,
+  `ok` is a word, the `You` chip is a word.


### PR DESCRIPTION
Three commits extending the call-prep area: the account brief, a read-only Google Calendar week strip, and a scoped UI auditor that persists its findings.

## Needs a Cloud console change before it works in prod

Two prerequisites on `project-for-method-dw`, both outside this repo. **The calendar panel will not work until these are done**, though nothing else on the page is affected:

1. **Google Calendar API must be enabled** on the project. If it isn't, every calendar call 403s.
2. **The OAuth consent screen must allow `calendar.readonly`.** It's a *sensitive* scope, so it's fine if the consent screen is Internal to method.me, but needs app verification if it's External.

The code handles the failure modes distinctly, so a missing prerequisite reads as a clear message rather than a broken screen: API-not-enabled is detected explicitly and never surfaces as a "Connect calendar" button someone could click forever.

Existing sessions are not disrupted. Tokens minted before the scope existed still validate against BigQuery, so nobody is logged out; `connectCalendar()` re-mints the token in place when the calendar is first used.

## What's in it

**Account brief** (`#/call-prep/account/:recordId`) — Opportunity Fit from `call_prep.opportunity_fit`, a Recent Activities timeline, and the prose sections from `call_prep.brief_content` (LEFT JOINed: it only ever covered 24 preps and stopped being written 2026-07-16, so older preps still render without it).

**Calendar week strip** (`#/call-prep/:consultant`) — read-only, showing when each call is. `call_prep.snapshots` knows *which* accounts you're speaking to on a day but not *when*; `brief_content` was the only source of clock times. On a teammate's book it reads their calendar if you're subscribed to it, and says so plainly if you aren't — no address is ever guessed, so the subscription is the permission check.

**Book and directory** — `#/call-prep` is now a searchable table with the signed-in rep sorted first; `#/call-prep/:consultant` gains Today / Past preps / Accounts tabs over one search box. The PS section was added to the sidebar; those routes existed but had no nav entry.

**At a glance** — which of today's calls has *no prep written* is now visible on the calendar card, along with the account's attention flags and a book-level count. All three come from data the page already loads, so no extra queries.

## Known judgement calls

- **Event-to-account matching is a heuristic.** No calendar id on an account, no domain column on `int_accounts`, so it matches on event title then attendee domain. Tuned to under-match; unmatched events are shown rather than dropped so a bad guess can't hide a meeting, and attendee-only matches are labelled as guesses. 26 unit tests pin the behaviour.
- **`#/call-prep` no longer auto-redirects** to your remembered book. The old `localStorage` redirect made the new table unreachable. Your book is one click instead of zero.
- **The Details section on the brief was cut to two fields.** Twelve of its fourteen entries repeated the identity block, stat strip or a rail card verbatim. If two items reads thin, the alternative is deleting the section and folding both fields into the Snapshot card — flagged rather than decided, since the section order deliberately mirrors the `/call-prep` Google Doc.

## The auditor

`/call-prep-ui-audit` sweeps the five call-prep files and writes `docs/ui-audit-call-prep.md` as a ledger with stable finding ids, so a re-run marks a finding fixed rather than renumbering. 24 findings across two runs, all applied.

Worth knowing how run 2 came about: run 1 called `CallPrepAccount.jsx` the strongest screen in the area, on the strength of its accessibility *attributes*. Challenged on it, run 2 re-read it as a screen and found one critical (eight sections, zero `<h2>`s) and five majors it had missed — including section titles set *smaller and greyer than the body text they introduced*. That lesson is written into the ledger so the next sweep doesn't repeat it.

## Verification

- `npx vitest run` — 42 files, 811 tests passing
- `npx eslint` clean on every changed file
- `vite build` clean; `builder/dist` deliberately not committed (CI builds it)
- Fixtures confirmed tree-shaken out of the production bundle by grepping `dist/` for fixture company names
